### PR TITLE
Implement proposal workflow completion

### DIFF
--- a/src/tessera/services/__init__.py
+++ b/src/tessera/services/__init__.py
@@ -5,8 +5,10 @@ from tessera.services.audit import (
     log_contract_published,
     log_event,
     log_proposal_acknowledged,
+    log_proposal_approved,
     log_proposal_created,
     log_proposal_force_approved,
+    log_proposal_rejected,
 )
 from tessera.services.schema_diff import (
     BreakingChange,
@@ -40,5 +42,7 @@ __all__ = [
     "log_contract_published",
     "log_proposal_created",
     "log_proposal_acknowledged",
+    "log_proposal_approved",
     "log_proposal_force_approved",
+    "log_proposal_rejected",
 ]

--- a/src/tessera/services/audit.py
+++ b/src/tessera/services/audit.py
@@ -159,3 +159,34 @@ async def log_proposal_force_approved(
         actor_id=actor_id,
         payload={"warning": "Proposal force-approved without full consumer acknowledgment"},
     )
+
+
+async def log_proposal_approved(
+    session: AsyncSession,
+    proposal_id: UUID,
+    acknowledged_count: int,
+) -> AuditEventDB:
+    """Log an auto-approval of a proposal when all consumers acknowledged."""
+    return await log_event(
+        session=session,
+        entity_type="proposal",
+        entity_id=proposal_id,
+        action=AuditAction.PROPOSAL_APPROVED,
+        payload={"acknowledged_count": acknowledged_count, "auto_approved": True},
+    )
+
+
+async def log_proposal_rejected(
+    session: AsyncSession,
+    proposal_id: UUID,
+    blocked_by: UUID,
+) -> AuditEventDB:
+    """Log a proposal rejection when a consumer blocks it."""
+    return await log_event(
+        session=session,
+        entity_type="proposal",
+        entity_id=proposal_id,
+        action=AuditAction.PROPOSAL_REJECTED,
+        actor_id=blocked_by,
+        payload={"reason": "Consumer blocked the proposal"},
+    )


### PR DESCRIPTION
## Summary
This PR completes the proposal workflow by implementing auto-approval, rejection handling, and contract publishing from approved proposals.

### Changes

1. **Auto-approval logic**: After each acknowledgment, checks if all registered consumers have acknowledged. If yes, automatically transitions proposal to APPROVED status.

2. **Rejection handling**: When a consumer responds with "blocked", the proposal is automatically rejected (status=REJECTED).

3. **Contract publishing from proposals**: New endpoint `POST /proposals/{id}/publish` allows creating a contract from an approved proposal.

4. **Audit logging**: Added logging for auto-approval and rejection events.

## New Endpoints

### Publish from Proposal
```
POST /api/v1/proposals/{id}/publish
{
  "version": "2.0.0",
  "published_by": "team-uuid"
}
```
- Requires proposal status = APPROVED
- Creates new contract with proposed schema
- Deprecates old contract
- Returns new contract details

## Edge Cases Handled

- **No registered consumers**: Proposal auto-approves immediately
- **Multiple consumers**: Waits for all to acknowledge
- **Consumer blocks**: Immediately rejects proposal

## Test plan
- [x] Schema diff tests pass (32 tests)
- [ ] Manual test auto-approval with registered consumer
- [ ] Manual test rejection with blocked response
- [ ] Manual test publish from approved proposal

Closes #22