### PR TITLE
Add upstream lineage tracking

### DIFF
--- a/src/tessera/db/__init__.py
+++ b/src/tessera/db/__init__.py
@@ -4,6 +4,7 @@ from tessera.db.database import get_session, init_db
 from tessera.db.models import (
     AcknowledgmentDB,
     AssetDB,
+    AssetDependencyDB,
     AuditEventDB,
     Base,
     ContractDB,
@@ -18,6 +19,7 @@ __all__ = [
     "init_db",
     "TeamDB",
     "AssetDB",
+    "AssetDependencyDB",
     "ContractDB",
     "RegistrationDB",
     "ProposalDB",

--- a/src/tessera/db/models.py
+++ b/src/tessera/db/models.py
@@ -12,6 +12,7 @@ from tessera.models.enums import (
     ChangeType,
     CompatibilityMode,
     ContractStatus,
+    DependencyType,
     ProposalStatus,
     RegistrationStatus,
 )
@@ -156,6 +157,25 @@ class AcknowledgmentDB(Base):
 
     # Relationships
     proposal: Mapped["ProposalDB"] = relationship(back_populates="acknowledgments")
+
+
+class AssetDependencyDB(Base):
+    """Asset-to-asset dependency for upstream lineage tracking."""
+
+    __tablename__ = "dependencies"
+    __table_args__ = {"schema": "core"}
+
+    id: Mapped[UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    dependent_asset_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("core.assets.id"), nullable=False
+    )
+    dependency_asset_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("core.assets.id"), nullable=False
+    )
+    dependency_type: Mapped[DependencyType] = mapped_column(
+        Enum(DependencyType), default=DependencyType.CONSUMES
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
 
 class AuditEventDB(Base):

--- a/src/tessera/models/__init__.py
+++ b/src/tessera/models/__init__.py
@@ -7,11 +7,13 @@ from tessera.models.acknowledgment import (
 )
 from tessera.models.asset import Asset, AssetCreate, AssetUpdate
 from tessera.models.contract import Contract, ContractCreate
+from tessera.models.dependency import Dependency, DependencyCreate
 from tessera.models.enums import (
     AcknowledgmentResponseType,
     ChangeType,
     CompatibilityMode,
     ContractStatus,
+    DependencyType,
     ProposalStatus,
     RegistrationStatus,
 )
@@ -25,6 +27,7 @@ __all__ = [
     "ChangeType",
     "CompatibilityMode",
     "ContractStatus",
+    "DependencyType",
     "ProposalStatus",
     "RegistrationStatus",
     # Team
@@ -38,6 +41,9 @@ __all__ = [
     # Contract
     "Contract",
     "ContractCreate",
+    # Dependency
+    "Dependency",
+    "DependencyCreate",
     # Registration
     "Registration",
     "RegistrationCreate",

--- a/src/tessera/models/dependency.py
+++ b/src/tessera/models/dependency.py
@@ -1,0 +1,27 @@
+"""Pydantic models for asset dependencies."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from tessera.models.enums import DependencyType
+
+
+class DependencyCreate(BaseModel):
+    """Request body for creating an asset dependency."""
+
+    depends_on_asset_id: UUID
+    dependency_type: DependencyType = DependencyType.CONSUMES
+
+
+class Dependency(BaseModel):
+    """Response model for an asset dependency."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    dependent_asset_id: UUID
+    dependency_asset_id: UUID
+    dependency_type: DependencyType
+    created_at: datetime

--- a/src/tessera/models/enums.py
+++ b/src/tessera/models/enums.py
@@ -51,3 +51,11 @@ class AcknowledgmentResponseType(StrEnum):
     APPROVED = "approved"
     BLOCKED = "blocked"
     MIGRATING = "migrating"
+
+
+class DependencyType(StrEnum):
+    """Type of asset-to-asset dependency."""
+
+    CONSUMES = "consumes"  # Direct data consumption (SELECT FROM)
+    REFERENCES = "references"  # Foreign key or reference
+    TRANSFORMS = "transforms"  # Data transformation (dbt model)


### PR DESCRIPTION
## Summary
This PR adds upstream lineage tracking, completing the dependency graph with both upstream (what this asset depends on) and downstream (who consumes this asset) visibility.

### Changes

1. **New DependencyType enum**: `consumes`, `references`, `transforms`
2. **New AssetDependencyDB model**: Tracks asset-to-asset dependencies
3. **Dependency management endpoints**:
   - `POST /assets/{id}/dependencies` - Register upstream dependency
   - `GET /assets/{id}/dependencies` - List dependencies
   - `DELETE /assets/{id}/dependencies/{id}` - Remove dependency
4. **Enhanced lineage endpoint**: Now returns `upstream` assets and `downstream_assets` in addition to consumer teams

## New Endpoints

### Register Dependency
```
POST /api/v1/assets/{asset_id}/dependencies
{
  "depends_on_asset_id": "uuid",
  "dependency_type": "consumes"
}
```

### Get Lineage (Enhanced)
```
GET /api/v1/assets/{asset_id}/lineage
```
Returns:
```json
{
  "upstream": [
    {"asset_id": "...", "asset_fqn": "...", "dependency_type": "consumes", "owner_team": "..."}
  ],
  "downstream": [...],
  "downstream_assets": [
    {"asset_id": "...", "asset_fqn": "...", "dependency_type": "transforms", "owner_team": "..."}
  ]
}
```

## Test plan
- [x] Schema diff tests pass (32 tests)
- [ ] Manual test dependency creation
- [ ] Manual test lineage endpoint with dependencies
- [ ] Manual test duplicate/self-dependency prevention

Closes #24