### PR TITLE
Add search, filtering, and pagination to API endpoints

### DIFF
--- a/src/tessera/api/contracts.py
+++ b/src/tessera/api/contracts.py
@@ -1,15 +1,54 @@
 """Contracts API endpoints."""
 
+from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tessera.db import ContractDB, RegistrationDB, get_session
 from tessera.models import Contract, Registration
+from tessera.models.enums import ContractStatus
 
 router = APIRouter()
+
+
+@router.get("")
+async def list_contracts(
+    asset_id: UUID | None = Query(None, description="Filter by asset ID"),
+    status: ContractStatus | None = Query(None, description="Filter by status"),
+    version: str | None = Query(None, description="Filter by version pattern"),
+    limit: int = Query(50, ge=1, le=100, description="Results per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
+    """List all contracts with filtering and pagination."""
+    query = select(ContractDB)
+    if asset_id:
+        query = query.where(ContractDB.asset_id == asset_id)
+    if status:
+        query = query.where(ContractDB.status == status)
+    if version:
+        query = query.where(ContractDB.version.ilike(f"%{version}%"))
+
+    # Get total count
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await session.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply pagination and ordering
+    query = query.order_by(ContractDB.published_at.desc())
+    query = query.limit(limit).offset(offset)
+    result = await session.execute(query)
+    contracts = result.scalars().all()
+
+    return {
+        "results": [Contract.model_validate(c).model_dump() for c in contracts],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @router.get("/{contract_id}", response_model=Contract)

--- a/src/tessera/api/teams.py
+++ b/src/tessera/api/teams.py
@@ -1,9 +1,10 @@
 """Teams API endpoints."""
 
+from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,13 +31,35 @@ async def create_team(
     return db_team
 
 
-@router.get("", response_model=list[Team])
+@router.get("")
 async def list_teams(
+    name: str | None = Query(None, description="Filter by name pattern (case-insensitive)"),
+    limit: int = Query(50, ge=1, le=100, description="Results per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
     session: AsyncSession = Depends(get_session),
-) -> list[TeamDB]:
-    """List all teams."""
-    result = await session.execute(select(TeamDB))
-    return list(result.scalars().all())
+) -> dict[str, Any]:
+    """List all teams with filtering and pagination."""
+    query = select(TeamDB)
+    if name:
+        query = query.where(TeamDB.name.ilike(f"%{name}%"))
+
+    # Get total count
+    count_query = select(func.count()).select_from(query.subquery())
+    total_result = await session.execute(count_query)
+    total = total_result.scalar() or 0
+
+    # Apply pagination and ordering
+    query = query.order_by(TeamDB.name)
+    query = query.limit(limit).offset(offset)
+    result = await session.execute(query)
+    teams = result.scalars().all()
+
+    return {
+        "results": [Team.model_validate(t).model_dump() for t in teams],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @router.get("/{team_id}", response_model=Team)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -98,7 +98,8 @@ class TestAssetsAPI:
         await client.post("/api/v1/assets", json={"fqn": "team2.asset", "owner_team_id": team2_id})
 
         resp = await client.get(f"/api/v1/assets?owner={team1_id}")
-        assets = resp.json()
+        data = resp.json()
+        assets = data["results"]
         assert all(a["owner_team_id"] == team1_id for a in assets)
 
 


### PR DESCRIPTION
## Summary
This PR adds search, filtering, and pagination capabilities to all list endpoints in the API.

### Changes

1. **Asset Search Endpoint**: `GET /assets/search?q=pattern`
2. **Pagination**: All list endpoints now support `limit` and `offset` parameters
3. **Filtering**: Enhanced filtering on all list endpoints
4. **Response Format**: List endpoints return `{results, total, limit, offset}` for pagination support

## New/Enhanced Endpoints

### Asset Search
```
GET /api/v1/assets/search?q=dim_customers&owner=uuid&limit=50&offset=0
```
Returns matching assets with owner team names.

### List Assets (Enhanced)
```
GET /api/v1/assets?fqn=pattern&owner=uuid&limit=50&offset=0
```

### List Contracts (New)
```
GET /api/v1/contracts?asset_id=uuid&status=active&version=1.0&limit=50&offset=0
```

### List Teams (Enhanced)
```
GET /api/v1/teams?name=pattern&limit=50&offset=0
```

## Response Format
All list endpoints now return:
```json
{
  "results": [...],
  "total": 100,
  "limit": 50,
  "offset": 0
}
```

## Test plan
- [x] Schema diff tests pass (32 tests)
- [ ] Manual test search with various patterns
- [ ] Manual test pagination with limit/offset
- [ ] Manual test filtering on each endpoint

Closes #30