### PR TITLE
Add Alembic migrations, CORS config, and enhanced health checks

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,146 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = src
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# env.py overrides this with DATABASE_URL from environment.
+sqlalchemy.url = postgresql+asyncpg://tessera:tessera@localhost:5432/tessera
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+hooks = ruff
+ruff.type = module
+ruff.module = ruff
+ruff.options = format REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,114 @@
+"""Alembic environment configuration."""
+
+import asyncio
+import os
+from logging.config import fileConfig
+
+from dotenv import load_dotenv
+from sqlalchemy import pool, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+# Load environment variables
+load_dotenv()
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Override sqlalchemy.url with environment variable if set
+database_url = os.environ.get("DATABASE_URL")
+if database_url:
+    # Convert async URL to sync for Alembic if needed
+    if database_url.startswith("postgresql+asyncpg"):
+        database_url = database_url.replace("postgresql+asyncpg", "postgresql+psycopg2")
+    config.set_main_option("sqlalchemy.url", database_url)
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Import models for autogenerate support
+from tessera.db.models import Base
+
+target_metadata = Base.metadata
+
+
+def include_name(name, type_, parent_names):
+    """Filter schemas to include in autogenerate."""
+    if type_ == "schema":
+        return name in ["core", "workflow", "audit"]
+    return True
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        include_schemas=True,
+        include_name=include_name,
+        version_table_schema="core",
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    """Run migrations with a connection."""
+    # Create schemas if they don't exist
+    connection.execute(text("CREATE SCHEMA IF NOT EXISTS core"))
+    connection.execute(text("CREATE SCHEMA IF NOT EXISTS workflow"))
+    connection.execute(text("CREATE SCHEMA IF NOT EXISTS audit"))
+    connection.commit()
+
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        include_schemas=True,
+        include_name=include_name,
+        version_table_schema="core",
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    """Run migrations in 'online' mode with async engine."""
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/001_initial_schema.py
+++ b/alembic/versions/001_initial_schema.py
@@ -1,0 +1,255 @@
+"""Initial schema.
+
+Revision ID: 001
+Revises:
+Create Date: 2024-12-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Create initial schema."""
+    if not _is_sqlite():
+        # PostgreSQL: Create schemas
+        op.execute("CREATE SCHEMA IF NOT EXISTS core")
+        op.execute("CREATE SCHEMA IF NOT EXISTS workflow")
+        op.execute("CREATE SCHEMA IF NOT EXISTS audit")
+
+    schema = None if _is_sqlite() else "core"
+    workflow_schema = None if _is_sqlite() else "workflow"
+    audit_schema = None if _is_sqlite() else "audit"
+
+    # Teams table
+    op.create_table(
+        "teams",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False, unique=True),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        schema=schema,
+    )
+
+    # Assets table
+    op.create_table(
+        "assets",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("fqn", sa.String(1000), nullable=False, unique=True),
+        sa.Column(
+            "owner_team_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}teams.id"),
+            nullable=False,
+        ),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        schema=schema,
+    )
+
+    # Contracts table
+    op.create_table(
+        "contracts",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "asset_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}assets.id"),
+            nullable=False,
+        ),
+        sa.Column("version", sa.String(50), nullable=False),
+        sa.Column("schema", sa.JSON(), nullable=False),
+        sa.Column(
+            "compatibility_mode",
+            sa.Enum(
+                "BACKWARD",
+                "FORWARD",
+                "FULL",
+                "NONE",
+                name="compatibilitymode",
+                schema=schema,
+            ),
+            nullable=False,
+        ),
+        sa.Column("guarantees", sa.JSON(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("ACTIVE", "DEPRECATED", "ARCHIVED", name="contractstatus", schema=schema),
+            nullable=False,
+        ),
+        sa.Column("published_at", sa.DateTime(), nullable=False),
+        sa.Column("published_by", sa.Uuid(), nullable=False),
+        schema=schema,
+    )
+
+    # Registrations table
+    op.create_table(
+        "registrations",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "contract_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}contracts.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "consumer_team_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}teams.id"),
+            nullable=False,
+        ),
+        sa.Column("pinned_version", sa.String(50), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("ACTIVE", "PAUSED", "REMOVED", name="registrationstatus", schema=schema),
+            nullable=False,
+        ),
+        sa.Column("registered_at", sa.DateTime(), nullable=False),
+        sa.Column("acknowledged_at", sa.DateTime(), nullable=True),
+        schema=schema,
+    )
+
+    # Dependencies table
+    op.create_table(
+        "dependencies",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "dependent_asset_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}assets.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "dependency_asset_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}assets.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "dependency_type",
+            sa.Enum("CONSUMES", "DERIVED_FROM", "REFERENCES", name="dependencytype", schema=schema),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        schema=schema,
+    )
+
+    # Proposals table (workflow schema)
+    op.create_table(
+        "proposals",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "asset_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}assets.id"),
+            nullable=False,
+        ),
+        sa.Column("proposed_schema", sa.JSON(), nullable=False),
+        sa.Column(
+            "change_type",
+            sa.Enum("ADDITIVE", "BREAKING", "COMPATIBLE", name="changetype", schema=workflow_schema),
+            nullable=False,
+        ),
+        sa.Column("breaking_changes", sa.JSON(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "PENDING",
+                "APPROVED",
+                "REJECTED",
+                "SUPERSEDED",
+                name="proposalstatus",
+                schema=workflow_schema,
+            ),
+            nullable=False,
+        ),
+        sa.Column("proposed_by", sa.Uuid(), nullable=False),
+        sa.Column("proposed_at", sa.DateTime(), nullable=False),
+        sa.Column("resolved_at", sa.DateTime(), nullable=True),
+        schema=workflow_schema,
+    )
+
+    # Acknowledgments table (workflow schema)
+    op.create_table(
+        "acknowledgments",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "proposal_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{workflow_schema + '.' if workflow_schema else ''}proposals.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "consumer_team_id",
+            sa.Uuid(),
+            sa.ForeignKey(f"{schema + '.' if schema else ''}teams.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "response",
+            sa.Enum(
+                "ACKNOWLEDGED",
+                "NEEDS_TIME",
+                "BLOCKED",
+                name="acknowledgmentresponsetype",
+                schema=workflow_schema,
+            ),
+            nullable=False,
+        ),
+        sa.Column("migration_deadline", sa.DateTime(), nullable=True),
+        sa.Column("responded_at", sa.DateTime(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        schema=workflow_schema,
+    )
+
+    # Audit events table (audit schema)
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("entity_type", sa.String(100), nullable=False),
+        sa.Column("entity_id", sa.Uuid(), nullable=False),
+        sa.Column("action", sa.String(100), nullable=False),
+        sa.Column("actor_id", sa.Uuid(), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        schema=audit_schema,
+    )
+
+
+def downgrade() -> None:
+    """Drop all tables and schemas."""
+    is_sqlite = _is_sqlite()
+    schema = None if is_sqlite else "core"
+    workflow_schema = None if is_sqlite else "workflow"
+    audit_schema = None if is_sqlite else "audit"
+
+    # Drop tables in reverse order (respecting foreign keys)
+    op.drop_table("events", schema=audit_schema)
+    op.drop_table("acknowledgments", schema=workflow_schema)
+    op.drop_table("proposals", schema=workflow_schema)
+    op.drop_table("dependencies", schema=schema)
+    op.drop_table("registrations", schema=schema)
+    op.drop_table("contracts", schema=schema)
+    op.drop_table("assets", schema=schema)
+    op.drop_table("teams", schema=schema)
+
+    if not is_sqlite:
+        # PostgreSQL: Drop schemas
+        op.execute("DROP SCHEMA IF EXISTS audit CASCADE")
+        op.execute("DROP SCHEMA IF EXISTS workflow CASCADE")
+        op.execute("DROP SCHEMA IF EXISTS core CASCADE")

--- a/src/tessera/config.py
+++ b/src/tessera/config.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -10,6 +11,9 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
+    # Environment
+    environment: str = "development"
+
     # Database
     database_url: str = "postgresql+asyncpg://tessera:tessera@localhost:5432/tessera"
 
@@ -17,6 +21,22 @@ class Settings(BaseSettings):
     api_host: str = "0.0.0.0"
     api_port: int = 8000
     api_reload: bool = False
+
+    # CORS
+    cors_origins: list[str] = [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "http://127.0.0.1:3000",
+        "http://127.0.0.1:5173",
+    ]
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, v: str | list[str]) -> list[str]:
+        """Parse CORS origins from comma-separated string or list."""
+        if isinstance(v, str):
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
 
     # Git sync
     git_sync_path: Path = Path("./contracts")


### PR DESCRIPTION
## Summary
- Add Alembic for database migrations with SQLite/PostgreSQL dialect support
- Initial migration creates all tables (teams, assets, contracts, registrations, dependencies, proposals, acknowledgments, events)
- Add CORS middleware with configurable origins via `CORS_ORIGINS` env var
- Add `/health/ready` (readiness probe with DB connectivity check)
- Add `/health/live` (liveness probe)

## Test plan
- [x] Tests pass with SQLite in-memory
- [ ] Verify Alembic migration runs against PostgreSQL
- [ ] Verify CORS headers in API responses
- [ ] Test health endpoints return expected JSON

Closes #17, closes #29, closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)