### PR TITLE
Fix P0/P2 critical bugs from codebase review

### DIFF
--- a/src/tessera/main.py
+++ b/src/tessera/main.py
@@ -14,6 +14,7 @@ from tessera.api.errors import (
     APIError,
     RequestIDMiddleware,
     api_error_handler,
+    generic_exception_handler,
     http_exception_handler,
     validation_exception_handler,
 )
@@ -52,6 +53,7 @@ app.add_middleware(
 app.add_exception_handler(APIError, api_error_handler)
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(ValidationError, validation_exception_handler)
+app.add_exception_handler(Exception, generic_exception_handler)
 
 # API v1 router
 api_v1 = APIRouter(prefix="/api/v1")


### PR DESCRIPTION
## Summary

This PR addresses production-blocking (P0) and hardening (P2) issues identified in the codebase review.

### P0 Fixes (Production-blocking)

- **Fix `compatibility_mode=None` crash in publish_from_proposal** (#43)
  - When publishing from a proposal for an asset with no existing contract, `compatibility_mode` was set to `None`, violating DB constraints
  - Now defaults to `BACKWARD` mode (safe for existing consumers)
  
- **Remove incomplete `POST /api/v1/proposals` endpoint** (#44)
  - Was hardcoded to `ChangeType.MAJOR` with empty `breaking_changes`
  - Conflicted with the real workflow (proposals are created during contract publishing)
  - Removed as it was an attractive footgun
  
- **Register `generic_exception_handler` in main.py** (#45)
  - Handler was defined but not registered
  - All unhandled exceptions now return consistent JSON error responses with request IDs

### P2 Fixes (Hardening)

- **Add DB indexes for common access patterns** (#46)
  - `ix_assets_fqn` - For FQN lookups
  - `ix_contracts_asset_status` - For finding active contracts
  - `ix_proposals_asset_status` - For proposal filtering
  - `ix_registrations_contract_status` - For registration queries  
  - `ix_events_entity` - For audit log queries

- **Add unique constraint on `(asset_id, version)`** (#47)
  - Prevents duplicate contract versions for the same asset

- **Add schema validation to `publish_from_proposal`** (#48)
  - Validates `proposed_schema` before publishing
  - Catches malformed schemas that could have been imported or created incorrectly

- **Fix enum value mismatches** (#50)
  - Migration had different enum values than Python StrEnums
  - Now uses correct lowercase values matching the application code

## Test plan

- [x] All 119 tests pass
- [x] Tests run with in-memory SQLite

## Closes

Closes #43, closes #44, closes #45, closes #46, closes #47, closes #48, closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)