### PR TITLE
Add CLI tool for Tessera operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,12 @@ dependencies = [
     "pyyaml>=6.0.0",
     "greenlet>=3.3.0",
     "jsonschema>=4.20.0",
+    "typer>=0.15.0",
+    "rich>=13.0.0",
 ]
+
+[project.scripts]
+tessera = "tessera.cli:app"
 
 [project.optional-dependencies]
 dev = [

--- a/src/tessera/cli/__init__.py
+++ b/src/tessera/cli/__init__.py
@@ -1,0 +1,562 @@
+"""Tessera CLI - Data contract coordination from the command line."""
+
+import json
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx
+import typer
+from rich.console import Console
+from rich.table import Table
+
+app = typer.Typer(
+    name="tessera",
+    help="Data contract coordination for warehouses",
+    no_args_is_help=True,
+)
+
+console = Console()
+err_console = Console(stderr=True)
+
+# Sub-commands
+team_app = typer.Typer(help="Manage teams")
+asset_app = typer.Typer(help="Manage assets")
+contract_app = typer.Typer(help="Manage contracts")
+proposal_app = typer.Typer(help="Manage breaking change proposals")
+
+app.add_typer(team_app, name="team")
+app.add_typer(asset_app, name="asset")
+app.add_typer(contract_app, name="contract")
+app.add_typer(proposal_app, name="proposal")
+
+
+def get_base_url() -> str:
+    """Get the Tessera API base URL from environment or default."""
+    import os
+
+    return os.environ.get("TESSERA_URL", "http://localhost:8000")
+
+
+def get_api_key() -> str | None:
+    """Get the API key from environment."""
+    import os
+
+    return os.environ.get("TESSERA_API_KEY")
+
+
+def make_request(
+    method: str,
+    path: str,
+    json_data: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Make an HTTP request to the Tessera API."""
+    url = f"{get_base_url()}/api/v1{path}"
+    headers: dict[str, str] = {}
+    api_key = get_api_key()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(
+            method=method,
+            url=url,
+            json=json_data,
+            params=params,
+            headers=headers,
+        )
+    return response
+
+
+def handle_response(response: httpx.Response) -> Any:
+    """Handle API response, raising on errors.
+
+    Returns the JSON response which may be a dict or list depending on the endpoint.
+    """
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("detail", response.text)
+        except Exception:
+            detail = response.text
+        err_console.print(f"[red]Error ({response.status_code}):[/red] {detail}")
+        raise typer.Exit(1)
+    if response.status_code == 204:
+        return {}
+    return response.json()
+
+
+# ============================================================================
+# Team commands
+# ============================================================================
+
+
+@team_app.command("create")
+def team_create(
+    name: Annotated[str, typer.Argument(help="Team name")],
+    metadata: Annotated[str | None, typer.Option("--metadata", "-m", help="JSON metadata")] = None,
+) -> None:
+    """Create a new team."""
+    data: dict[str, Any] = {"name": name}
+    if metadata:
+        data["metadata"] = json.loads(metadata)
+
+    response = make_request("POST", "/teams", json_data=data)
+    team = handle_response(response)
+    console.print(f"[green]Created team:[/green] {team['name']} (id: {team['id']})")
+
+
+@team_app.command("list")
+def team_list() -> None:
+    """List all teams."""
+    response = make_request("GET", "/teams")
+    teams = handle_response(response)
+
+    if not teams:
+        console.print("[dim]No teams found[/dim]")
+        return
+
+    table = Table(title="Teams")
+    table.add_column("ID", style="dim")
+    table.add_column("Name", style="bold")
+    table.add_column("Created")
+
+    for team in teams:
+        table.add_row(team["id"], team["name"], team["created_at"][:10])
+
+    console.print(table)
+
+
+@team_app.command("get")
+def team_get(
+    team_id: Annotated[str, typer.Argument(help="Team ID")],
+) -> None:
+    """Get team details."""
+    response = make_request("GET", f"/teams/{team_id}")
+    team = handle_response(response)
+    console.print_json(json.dumps(team))
+
+
+# ============================================================================
+# Asset commands
+# ============================================================================
+
+
+@asset_app.command("create")
+def asset_create(
+    fqn: Annotated[str, typer.Argument(help="Fully qualified name (e.g., warehouse.schema.table)")],
+    owner_team_id: Annotated[str, typer.Option("--team", "-t", help="Owner team ID")],
+    metadata: Annotated[str | None, typer.Option("--metadata", "-m", help="JSON metadata")] = None,
+) -> None:
+    """Create a new asset."""
+    data: dict[str, Any] = {"fqn": fqn, "owner_team_id": owner_team_id}
+    if metadata:
+        data["metadata"] = json.loads(metadata)
+
+    response = make_request("POST", "/assets", json_data=data)
+    asset = handle_response(response)
+    console.print(f"[green]Created asset:[/green] {asset['fqn']} (id: {asset['id']})")
+
+
+@asset_app.command("list")
+def asset_list(
+    team_id: Annotated[str | None, typer.Option("--team", "-t", help="Filter by team ID")] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l", help="Max results")] = 50,
+) -> None:
+    """List assets."""
+    params: dict[str, Any] = {"limit": limit}
+    if team_id:
+        params["team_id"] = team_id
+
+    response = make_request("GET", "/assets", params=params)
+    result = handle_response(response)
+    assets = result.get("items", [])
+
+    if not assets:
+        console.print("[dim]No assets found[/dim]")
+        return
+
+    table = Table(title="Assets")
+    table.add_column("ID", style="dim")
+    table.add_column("FQN", style="bold")
+    table.add_column("Owner Team")
+
+    for asset in assets:
+        table.add_row(asset["id"], asset["fqn"], asset["owner_team_id"])
+
+    console.print(table)
+
+
+@asset_app.command("get")
+def asset_get(
+    asset_id: Annotated[str, typer.Argument(help="Asset ID")],
+) -> None:
+    """Get asset details."""
+    response = make_request("GET", f"/assets/{asset_id}")
+    asset = handle_response(response)
+    console.print_json(json.dumps(asset))
+
+
+@asset_app.command("search")
+def asset_search(
+    query: Annotated[str, typer.Argument(help="Search query (matches FQN)")],
+    limit: Annotated[int, typer.Option("--limit", "-l", help="Max results")] = 20,
+) -> None:
+    """Search for assets by FQN."""
+    params = {"q": query, "limit": limit}
+    response = make_request("GET", "/assets/search", params=params)
+    result = handle_response(response)
+    assets = result.get("items", [])
+
+    if not assets:
+        console.print(f"[dim]No assets matching '{query}'[/dim]")
+        return
+
+    table = Table(title=f"Assets matching '{query}'")
+    table.add_column("ID", style="dim")
+    table.add_column("FQN", style="bold")
+
+    for asset in assets:
+        table.add_row(asset["id"], asset["fqn"])
+
+    console.print(table)
+
+
+# ============================================================================
+# Contract commands
+# ============================================================================
+
+
+@contract_app.command("publish")
+def contract_publish(
+    asset_id: Annotated[str, typer.Option("--asset", "-a", help="Asset ID")],
+    version: Annotated[str, typer.Option("--version", "-v", help="Contract version")],
+    schema_file: Annotated[Path, typer.Option("--schema", "-s", help="Path to JSON schema file")],
+    team_id: Annotated[str, typer.Option("--team", "-t", help="Publisher team ID")],
+    compatibility: Annotated[
+        str, typer.Option("--compat", "-c", help="Compatibility mode")
+    ] = "backward",
+    force: Annotated[
+        bool, typer.Option("--force", "-f", help="Force publish breaking changes")
+    ] = False,
+) -> None:
+    """Publish a new contract version."""
+    if not schema_file.exists():
+        err_console.print(f"[red]Schema file not found:[/red] {schema_file}")
+        raise typer.Exit(1)
+
+    schema = json.loads(schema_file.read_text())
+    data = {
+        "version": version,
+        "schema": schema,
+        "compatibility_mode": compatibility,
+        "publisher_team_id": team_id,
+        "force": force,
+    }
+
+    response = make_request("POST", f"/assets/{asset_id}/contracts", json_data=data)
+    result = handle_response(response)
+
+    if "proposal" in result:
+        proposal = result["proposal"]
+        console.print("[yellow]Breaking change detected![/yellow]")
+        console.print(f"Proposal created: {proposal['id']}")
+        console.print(f"Status: {proposal['status']}")
+        if result.get("breaking_changes"):
+            console.print("\nBreaking changes:")
+            for bc in result["breaking_changes"]:
+                console.print(f"  - {bc['change_type']}: {bc['message']}")
+    else:
+        contract = result.get("contract", result)
+        console.print(f"[green]Published contract:[/green] v{contract['version']}")
+
+
+@contract_app.command("list")
+def contract_list(
+    asset_id: Annotated[str, typer.Argument(help="Asset ID")],
+) -> None:
+    """List contracts for an asset."""
+    response = make_request("GET", f"/assets/{asset_id}/contracts")
+    contracts = handle_response(response)
+
+    if not contracts:
+        console.print("[dim]No contracts found[/dim]")
+        return
+
+    table = Table(title="Contracts")
+    table.add_column("ID", style="dim")
+    table.add_column("Version", style="bold")
+    table.add_column("Status")
+    table.add_column("Published")
+
+    for contract in contracts:
+        status_style = "green" if contract["status"] == "active" else "dim"
+        table.add_row(
+            contract["id"],
+            contract["version"],
+            f"[{status_style}]{contract['status']}[/{status_style}]",
+            contract["published_at"][:10],
+        )
+
+    console.print(table)
+
+
+@contract_app.command("diff")
+def contract_diff(
+    asset_id: Annotated[str, typer.Argument(help="Asset ID")],
+    from_version: Annotated[str, typer.Option("--from", help="From version")] = "",
+    to_version: Annotated[str, typer.Option("--to", help="To version")] = "",
+) -> None:
+    """Show differences between contract versions."""
+    params = {}
+    if from_version:
+        params["from_version"] = from_version
+    if to_version:
+        params["to_version"] = to_version
+
+    response = make_request("GET", f"/assets/{asset_id}/contracts/diff", params=params)
+    result = handle_response(response)
+
+    console.print(f"[bold]Comparing:[/bold] v{result['from_version']} -> v{result['to_version']}")
+    console.print(f"[bold]Change type:[/bold] {result['change_type']}")
+    console.print(f"[bold]Is breaking:[/bold] {result['is_breaking']}")
+
+    if result.get("changes"):
+        console.print("\n[bold]Changes:[/bold]")
+        for change in result["changes"]:
+            style = "red" if change.get("breaking") else "green"
+            console.print(f"  [{style}]{change['change_type']}[/{style}]: {change['message']}")
+
+
+@contract_app.command("impact")
+def contract_impact(
+    asset_id: Annotated[str, typer.Argument(help="Asset ID")],
+    schema_file: Annotated[
+        Path, typer.Option("--schema", "-s", help="Path to proposed JSON schema file")
+    ],
+) -> None:
+    """Analyze impact of a proposed schema change."""
+    if not schema_file.exists():
+        err_console.print(f"[red]Schema file not found:[/red] {schema_file}")
+        raise typer.Exit(1)
+
+    schema = json.loads(schema_file.read_text())
+    data = {"proposed_schema": schema}
+
+    response = make_request("POST", f"/assets/{asset_id}/impact", json_data=data)
+    result = handle_response(response)
+
+    console.print(f"[bold]Change type:[/bold] {result['change_type']}")
+    console.print(f"[bold]Is breaking:[/bold] {result['is_breaking']}")
+
+    if result.get("breaking_changes"):
+        console.print("\n[red]Breaking changes:[/red]")
+        for bc in result["breaking_changes"]:
+            console.print(f"  - {bc['change_type']}: {bc['message']}")
+
+    if result.get("impacted_consumers"):
+        console.print(f"\n[yellow]Impacted consumers:[/yellow] {len(result['impacted_consumers'])}")
+        for consumer in result["impacted_consumers"]:
+            pinned = consumer.get("pinned_version", "none")
+            console.print(f"  - {consumer['team_name']} (pinned: {pinned})")
+
+
+# ============================================================================
+# Proposal commands
+# ============================================================================
+
+
+@proposal_app.command("list")
+def proposal_list(
+    status: Annotated[str | None, typer.Option("--status", "-s", help="Filter by status")] = None,
+    asset_id: Annotated[
+        str | None, typer.Option("--asset", "-a", help="Filter by asset ID")
+    ] = None,
+    limit: Annotated[int, typer.Option("--limit", "-l", help="Max results")] = 50,
+) -> None:
+    """List breaking change proposals."""
+    params: dict[str, Any] = {"limit": limit}
+    if status:
+        params["status"] = status
+    if asset_id:
+        params["asset_id"] = asset_id
+
+    response = make_request("GET", "/proposals", params=params)
+    result = handle_response(response)
+    proposals = result.get("items", [])
+
+    if not proposals:
+        console.print("[dim]No proposals found[/dim]")
+        return
+
+    table = Table(title="Breaking Change Proposals")
+    table.add_column("ID", style="dim")
+    table.add_column("Asset ID")
+    table.add_column("Status", style="bold")
+    table.add_column("Proposed")
+
+    for p in proposals:
+        status_style = {
+            "pending": "yellow",
+            "approved": "green",
+            "rejected": "red",
+            "force_approved": "cyan",
+            "withdrawn": "dim",
+        }.get(p["status"], "white")
+        table.add_row(
+            p["id"][:8] + "...",
+            p["asset_id"][:8] + "...",
+            f"[{status_style}]{p['status']}[/{status_style}]",
+            p["proposed_at"][:10],
+        )
+
+    console.print(table)
+
+
+@proposal_app.command("get")
+def proposal_get(
+    proposal_id: Annotated[str, typer.Argument(help="Proposal ID")],
+) -> None:
+    """Get proposal details."""
+    response = make_request("GET", f"/proposals/{proposal_id}")
+    proposal = handle_response(response)
+    console.print_json(json.dumps(proposal))
+
+
+@proposal_app.command("status")
+def proposal_status(
+    proposal_id: Annotated[str, typer.Argument(help="Proposal ID")],
+) -> None:
+    """Get proposal acknowledgment status."""
+    response = make_request("GET", f"/proposals/{proposal_id}/status")
+    status = handle_response(response)
+
+    console.print(f"[bold]Proposal:[/bold] {status['proposal_id']}")
+    console.print(f"[bold]Status:[/bold] {status['status']}")
+    console.print(f"[bold]Pending:[/bold] {status['pending_count']}")
+    console.print(f"[bold]Acknowledged:[/bold] {status['acknowledged_count']}")
+    console.print(f"[bold]Can publish:[/bold] {status['can_publish']}")
+
+    if status.get("acknowledgments"):
+        console.print("\n[bold]Acknowledgments:[/bold]")
+        for ack in status["acknowledgments"]:
+            style = "green" if ack["response"] == "approved" else "yellow"
+            console.print(f"  [{style}]{ack['consumer_team_name']}[/{style}]: {ack['response']}")
+
+
+@proposal_app.command("acknowledge")
+def proposal_acknowledge(
+    proposal_id: Annotated[str, typer.Argument(help="Proposal ID")],
+    team_id: Annotated[str, typer.Option("--team", "-t", help="Consumer team ID")],
+    response_type: Annotated[
+        str, typer.Option("--response", "-r", help="Response: approved, blocked, or migrating")
+    ] = "approved",
+    notes: Annotated[str | None, typer.Option("--notes", "-n", help="Optional notes")] = None,
+) -> None:
+    """Acknowledge a breaking change proposal."""
+    data: dict[str, Any] = {
+        "consumer_team_id": team_id,
+        "response": response_type,
+    }
+    if notes:
+        data["notes"] = notes
+
+    resp = make_request("POST", f"/proposals/{proposal_id}/acknowledge", json_data=data)
+    ack = handle_response(resp)
+    console.print(f"[green]Acknowledged:[/green] {ack['response']}")
+
+
+@proposal_app.command("withdraw")
+def proposal_withdraw(
+    proposal_id: Annotated[str, typer.Argument(help="Proposal ID")],
+    team_id: Annotated[str, typer.Option("--team", "-t", help="Producer team ID")],
+) -> None:
+    """Withdraw a pending proposal."""
+    data = {"actor_team_id": team_id}
+    response = make_request("POST", f"/proposals/{proposal_id}/withdraw", json_data=data)
+    proposal = handle_response(response)
+    console.print(f"[green]Withdrawn:[/green] {proposal['id']}")
+
+
+@proposal_app.command("force")
+def proposal_force(
+    proposal_id: Annotated[str, typer.Argument(help="Proposal ID")],
+    team_id: Annotated[str, typer.Option("--team", "-t", help="Producer team ID")],
+) -> None:
+    """Force approve a proposal (skips consumer acknowledgment)."""
+    data = {"actor_team_id": team_id}
+    response = make_request("POST", f"/proposals/{proposal_id}/force", json_data=data)
+    proposal = handle_response(response)
+    console.print(f"[yellow]Force approved:[/yellow] {proposal['id']}")
+
+
+@proposal_app.command("publish")
+def proposal_publish(
+    proposal_id: Annotated[str, typer.Argument(help="Proposal ID")],
+    team_id: Annotated[str, typer.Option("--team", "-t", help="Publisher team ID")],
+) -> None:
+    """Publish an approved proposal as a new contract."""
+    data = {"publisher_team_id": team_id}
+    response = make_request("POST", f"/proposals/{proposal_id}/publish", json_data=data)
+    result = handle_response(response)
+    contract = result.get("contract", result)
+    console.print(f"[green]Published:[/green] v{contract['version']}")
+
+
+# ============================================================================
+# Registration command (top-level for convenience)
+# ============================================================================
+
+
+@app.command("register")
+def register(
+    asset_id: Annotated[str, typer.Option("--asset", "-a", help="Asset ID")],
+    team_id: Annotated[str, typer.Option("--team", "-t", help="Consumer team ID")],
+    pinned_version: Annotated[
+        str | None, typer.Option("--pin", "-p", help="Pin to specific version")
+    ] = None,
+) -> None:
+    """Register as a consumer of an asset."""
+    data: dict[str, Any] = {
+        "asset_id": asset_id,
+        "consumer_team_id": team_id,
+    }
+    if pinned_version:
+        data["pinned_version"] = pinned_version
+
+    response = make_request("POST", "/registrations", json_data=data)
+    reg = handle_response(response)
+    console.print(f"[green]Registered:[/green] {reg['id']}")
+    if reg.get("pinned_version"):
+        console.print(f"  Pinned to: v{reg['pinned_version']}")
+
+
+# ============================================================================
+# Server command
+# ============================================================================
+
+
+@app.command("serve")
+def serve(
+    host: Annotated[str, typer.Option("--host", "-h", help="Host to bind")] = "0.0.0.0",
+    port: Annotated[int, typer.Option("--port", "-p", help="Port to bind")] = 8000,
+    reload: Annotated[bool, typer.Option("--reload", "-r", help="Enable auto-reload")] = False,
+) -> None:
+    """Start the Tessera API server."""
+    import uvicorn
+
+    uvicorn.run("tessera.main:app", host=host, port=port, reload=reload)
+
+
+# ============================================================================
+# Version command
+# ============================================================================
+
+
+@app.command("version")
+def version() -> None:
+    """Show Tessera version."""
+    console.print("tessera 0.1.0")
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,428 @@
+"""Tests for the Tessera CLI."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from tessera.cli import app
+
+runner = CliRunner()
+
+
+class TestVersion:
+    """Tests for the version command."""
+
+    def test_version(self) -> None:
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert "tessera 0.1.0" in result.output
+
+
+class TestTeamCommands:
+    """Tests for team subcommands."""
+
+    def test_team_create_success(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "id": "team-123",
+            "name": "Data Platform",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["team", "create", "Data Platform"])
+            assert result.exit_code == 0
+            assert "Created team:" in result.output
+            assert "Data Platform" in result.output
+
+    def test_team_create_with_metadata(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "id": "team-123",
+            "name": "Data Platform",
+            "metadata": {"slack": "#data-platform"},
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response) as mock_req:
+            result = runner.invoke(
+                app, ["team", "create", "Data Platform", "-m", '{"slack": "#data-platform"}']
+            )
+            assert result.exit_code == 0
+            # Verify metadata was passed
+            call_args = mock_req.call_args
+            assert call_args[1]["json_data"]["metadata"] == {"slack": "#data-platform"}
+
+    def test_team_list_empty(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["team", "list"])
+            assert result.exit_code == 0
+            assert "No teams found" in result.output
+
+    def test_team_list_with_teams(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": "team-1", "name": "Team A", "created_at": "2024-01-01T00:00:00Z"},
+            {"id": "team-2", "name": "Team B", "created_at": "2024-01-02T00:00:00Z"},
+        ]
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["team", "list"])
+            assert result.exit_code == 0
+            assert "Team A" in result.output
+            assert "Team B" in result.output
+
+    def test_team_get(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "team-123",
+            "name": "Data Platform",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["team", "get", "team-123"])
+            assert result.exit_code == 0
+            assert "team-123" in result.output
+
+
+class TestAssetCommands:
+    """Tests for asset subcommands."""
+
+    def test_asset_create_success(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "id": "asset-123",
+            "fqn": "warehouse.schema.users",
+            "owner_team_id": "team-1",
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(
+                app, ["asset", "create", "warehouse.schema.users", "--team", "team-1"]
+            )
+            assert result.exit_code == 0
+            assert "Created asset:" in result.output
+            assert "warehouse.schema.users" in result.output
+
+    def test_asset_list_empty(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"items": []}
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["asset", "list"])
+            assert result.exit_code == 0
+            assert "No assets found" in result.output
+
+    def test_asset_list_with_assets(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "items": [
+                {"id": "a1", "fqn": "db.schema.table1", "owner_team_id": "t1"},
+                {"id": "a2", "fqn": "db.schema.table2", "owner_team_id": "t2"},
+            ]
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["asset", "list"])
+            assert result.exit_code == 0
+            assert "table1" in result.output
+            assert "table2" in result.output
+
+    def test_asset_search(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "items": [{"id": "a1", "fqn": "db.schema.users"}]
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["asset", "search", "users"])
+            assert result.exit_code == 0
+            assert "users" in result.output
+
+
+class TestContractCommands:
+    """Tests for contract subcommands."""
+
+    def test_contract_publish_file_not_found(self, tmp_path: pytest.TempPathFactory) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "contract",
+                "publish",
+                "--asset",
+                "a1",
+                "--version",
+                "1.0.0",
+                "--schema",
+                "/nonexistent/schema.json",
+                "--team",
+                "t1",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Schema file not found" in result.output
+
+    def test_contract_publish_success(self, tmp_path: pytest.TempPathFactory) -> None:
+        # Create a temporary schema file
+        schema_file = tmp_path / "schema.json"  # type: ignore[operator]
+        schema = {"type": "object", "properties": {"id": {"type": "string"}}}
+        schema_file.write_text(json.dumps(schema))
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "contract": {"id": "c1", "version": "1.0.0", "status": "active"}
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(
+                app,
+                [
+                    "contract",
+                    "publish",
+                    "--asset",
+                    "a1",
+                    "--version",
+                    "1.0.0",
+                    "--schema",
+                    str(schema_file),
+                    "--team",
+                    "t1",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Published contract:" in result.output
+            assert "v1.0.0" in result.output
+
+    def test_contract_publish_breaking_change(self, tmp_path: pytest.TempPathFactory) -> None:
+        schema_file = tmp_path / "schema.json"  # type: ignore[operator]
+        schema = {"type": "object", "properties": {"id": {"type": "string"}}}
+        schema_file.write_text(json.dumps(schema))
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "proposal": {"id": "p1", "status": "pending"},
+            "breaking_changes": [{"change_type": "field_removed", "message": "Field 'name' removed"}],
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(
+                app,
+                [
+                    "contract",
+                    "publish",
+                    "--asset",
+                    "a1",
+                    "--version",
+                    "2.0.0",
+                    "--schema",
+                    str(schema_file),
+                    "--team",
+                    "t1",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Breaking change detected" in result.output
+            assert "field_removed" in result.output
+
+    def test_contract_list_empty(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["contract", "list", "asset-123"])
+            assert result.exit_code == 0
+            assert "No contracts found" in result.output
+
+    def test_contract_list_with_contracts(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": "c1", "version": "1.0.0", "status": "deprecated", "published_at": "2024-01-01T00:00:00Z"},
+            {"id": "c2", "version": "2.0.0", "status": "active", "published_at": "2024-01-02T00:00:00Z"},
+        ]
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["contract", "list", "asset-123"])
+            assert result.exit_code == 0
+            assert "1.0.0" in result.output
+            assert "2.0.0" in result.output
+
+    def test_contract_diff(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "from_version": "1.0.0",
+            "to_version": "2.0.0",
+            "change_type": "minor",
+            "is_breaking": False,
+            "changes": [{"change_type": "field_added", "message": "Added field 'email'", "breaking": False}],
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["contract", "diff", "asset-123"])
+            assert result.exit_code == 0
+            assert "1.0.0" in result.output
+            assert "2.0.0" in result.output
+            assert "field_added" in result.output
+
+
+class TestProposalCommands:
+    """Tests for proposal subcommands."""
+
+    def test_proposal_list_empty(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"items": []}
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["proposal", "list"])
+            assert result.exit_code == 0
+            assert "No proposals found" in result.output
+
+    def test_proposal_status(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "proposal_id": "p1",
+            "status": "pending",
+            "pending_count": 2,
+            "acknowledged_count": 1,
+            "can_publish": False,
+            "acknowledgments": [
+                {"consumer_team_name": "Team A", "response": "approved"},
+            ],
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["proposal", "status", "p1"])
+            assert result.exit_code == 0
+            assert "pending" in result.output
+            assert "Team A" in result.output
+
+    def test_proposal_acknowledge(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "ack-1", "response": "approved"}
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(
+                app, ["proposal", "acknowledge", "p1", "--team", "t1", "--response", "approved"]
+            )
+            assert result.exit_code == 0
+            assert "Acknowledged:" in result.output
+
+    def test_proposal_force(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "p1", "status": "force_approved"}
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["proposal", "force", "p1", "--team", "t1"])
+            assert result.exit_code == 0
+            assert "Force approved:" in result.output
+
+
+class TestRegisterCommand:
+    """Tests for the register command."""
+
+    def test_register_success(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"id": "reg-1", "asset_id": "a1", "consumer_team_id": "t1"}
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["register", "--asset", "a1", "--team", "t1"])
+            assert result.exit_code == 0
+            assert "Registered:" in result.output
+
+    def test_register_with_pin(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 201
+        mock_response.json.return_value = {
+            "id": "reg-1",
+            "asset_id": "a1",
+            "consumer_team_id": "t1",
+            "pinned_version": "1.0.0",
+        }
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(
+                app, ["register", "--asset", "a1", "--team", "t1", "--pin", "1.0.0"]
+            )
+            assert result.exit_code == 0
+            assert "Pinned to:" in result.output
+            assert "v1.0.0" in result.output
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    def test_api_error_response(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 404
+        mock_response.text = "Not found"
+        mock_response.json.return_value = {"detail": "Team not found"}
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["team", "get", "nonexistent"])
+            assert result.exit_code == 1
+            assert "Error (404)" in result.output
+            assert "Team not found" in result.output
+
+    def test_api_error_no_json(self) -> None:
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_response.json.side_effect = Exception("Invalid JSON")
+
+        with patch("tessera.cli.make_request", return_value=mock_response):
+            result = runner.invoke(app, ["team", "get", "team-1"])
+            assert result.exit_code == 1
+            assert "Error (500)" in result.output
+
+
+class TestHelpOutput:
+    """Tests for help output."""
+
+    def test_main_help(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "Data contract coordination" in result.output
+        assert "team" in result.output
+        assert "asset" in result.output
+        assert "contract" in result.output
+        assert "proposal" in result.output
+
+    def test_team_help(self) -> None:
+        result = runner.invoke(app, ["team", "--help"])
+        assert result.exit_code == 0
+        assert "create" in result.output
+        assert "list" in result.output
+        assert "get" in result.output
+
+    def test_contract_help(self) -> None:
+        result = runner.invoke(app, ["contract", "--help"])
+        assert result.exit_code == 0
+        assert "publish" in result.output
+        assert "list" in result.output
+        assert "diff" in result.output
+        assert "impact" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -527,6 +527,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -598,6 +610,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -966,6 +987,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1100,6 +1134,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.45"
 source = { registry = "https://pypi.org/simple" }
@@ -1169,7 +1212,9 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "rich" },
     { name = "sqlalchemy" },
+    { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1206,8 +1251,10 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "typer", specifier = ">=0.15.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev"]
@@ -1267,6 +1314,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/c1/933d30fd7a123ed981e2a1eedafceab63cb379db0402e438a13bc51bbb15/typer-0.20.1.tar.gz", hash = "sha256:68585eb1b01203689c4199bc440d6be616f0851e9f0eb41e4a778845c5a0fd5b", size = 105968, upload-time = "2025-12-19T16:48:56.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/52/1f2df7e7d1be3d65ddc2936d820d4a3d9777a54f4204f5ca46b8513eff77/typer-0.20.1-py3-none-any.whl", hash = "sha256:4b3bde918a67c8e03d861aa02deca90a95bbac572e71b1b9be56ff49affdb5a8", size = 47381, upload-time = "2025-12-19T16:48:53.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a Typer-based CLI for managing Tessera resources from the command line
- Implements commands for teams, assets, contracts, and proposals
- Includes a `serve` command to start the API server directly

## Commands

| Command | Description |
|---------|-------------|
| `tessera team create/list/get` | Manage teams |
| `tessera asset create/list/get/search` | Manage assets |
| `tessera contract publish/list/diff/impact` | Manage contracts |
| `tessera proposal list/get/status/acknowledge/withdraw/force/publish` | Manage breaking change proposals |
| `tessera register` | Register as consumer of an asset |
| `tessera serve` | Start the API server |
| `tessera version` | Show CLI version |

## Configuration

- `TESSERA_URL`: API base URL (default: `http://localhost:8000`)
- `TESSERA_API_KEY`: Optional API key for authentication

## Test plan

- [x] All 27 CLI tests pass
- [x] Full test suite passes (168 tests)
- [x] Lint and type checks pass
- [ ] CI passes on GitHub