### PR TITLE
Fix CLI to use 'results' key for paginated API responses (#87)

### DIFF
--- a/src/tessera/cli/__init__.py
+++ b/src/tessera/cli/__init__.py
@@ -169,7 +169,7 @@ def asset_list(
 
     response = make_request("GET", "/assets", params=params)
     result = handle_response(response)
-    assets = result.get("items", [])
+    assets = result.get("results", [])
 
     if not assets:
         console.print("[dim]No assets found[/dim]")
@@ -205,7 +205,7 @@ def asset_search(
     params = {"q": query, "limit": limit}
     response = make_request("GET", "/assets/search", params=params)
     result = handle_response(response)
-    assets = result.get("items", [])
+    assets = result.get("results", [])
 
     if not assets:
         console.print(f"[dim]No assets matching '{query}'[/dim]")
@@ -382,7 +382,7 @@ def proposal_list(
 
     response = make_request("GET", "/proposals", params=params)
     result = handle_response(response)
-    proposals = result.get("items", [])
+    proposals = result.get("results", [])
 
     if not proposals:
         console.print("[dim]No proposals found[/dim]")

--- a/src/tessera/cli/dbt.py
+++ b/src/tessera/cli/dbt.py
@@ -241,7 +241,7 @@ def check(
                 continue
 
             search_result = resp.json()
-            items = search_result.get("items", [])
+            items = search_result.get("results", [])
 
             if not items:
                 # New model, not registered
@@ -440,7 +440,7 @@ def sync(
             continue
 
         search_result = resp.json()
-        items = search_result.get("items", [])
+        items = search_result.get("results", [])
 
         if items:
             asset = items[0]
@@ -564,7 +564,7 @@ def register_consumers(
         # Search for asset in Tessera
         resp = make_request("GET", "/assets/search", params={"q": fqn, "limit": 1})
         if resp.status_code == 200:
-            items = resp.json().get("items", [])
+            items = resp.json().get("results", [])
             if items:
                 asset = items[0]
                 # Register as consumer

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,7 +120,7 @@ class TestAssetCommands:
     def test_asset_list_empty(self) -> None:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.json.return_value = {"items": []}
+        mock_response.json.return_value = {"results": []}
 
         with patch("tessera.cli.make_request", return_value=mock_response):
             result = runner.invoke(app, ["asset", "list"])
@@ -131,7 +131,7 @@ class TestAssetCommands:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "items": [
+            "results": [
                 {"id": "a1", "fqn": "db.schema.table1", "owner_team_id": "t1"},
                 {"id": "a2", "fqn": "db.schema.table2", "owner_team_id": "t2"},
             ]
@@ -147,7 +147,7 @@ class TestAssetCommands:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "items": [{"id": "a1", "fqn": "db.schema.users"}]
+            "results": [{"id": "a1", "fqn": "db.schema.users"}]
         }
 
         with patch("tessera.cli.make_request", return_value=mock_response):
@@ -291,7 +291,7 @@ class TestProposalCommands:
     def test_proposal_list_empty(self) -> None:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.json.return_value = {"items": []}
+        mock_response.json.return_value = {"results": []}
 
         with patch("tessera.cli.make_request", return_value=mock_response):
             result = runner.invoke(app, ["proposal", "list"])


### PR DESCRIPTION
## Summary
- Fix CLI commands that were looking for `items` key when the API returns `results`
- This caused `tessera asset list`, `tessera asset search`, and `tessera proposal list` to show "No results found" even when data existed

## Changes
- Updated `cli/__init__.py`: Fixed `asset_list`, `asset_search`, and `proposal_list` commands
- Updated `cli/dbt.py`: Fixed `check`, `sync`, and `register_consumers` functions
- Updated test mocks in `tests/test_cli.py` to use `results` key

## Test plan
- [x] All 168 tests pass
- [x] CLI commands now correctly parse paginated responses

Fixes #87