### PR TITLE
Add webhook delivery tracking and query API (#88)

### DIFF
--- a/src/tessera/api/webhooks.py
+++ b/src/tessera/api/webhooks.py
@@ -1,0 +1,121 @@
+"""Webhook delivery API endpoints."""
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tessera.db.database import get_session
+from tessera.db.models import WebhookDeliveryDB
+from tessera.models.enums import WebhookDeliveryStatus
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+
+class WebhookDeliveryResponse(BaseModel):
+    """Response model for webhook delivery."""
+
+    id: UUID
+    event_type: str
+    payload: dict[str, Any]
+    url: str
+    status: WebhookDeliveryStatus
+    attempts: int
+    last_attempt_at: datetime | None
+    last_error: str | None
+    last_status_code: int | None
+    created_at: datetime
+    delivered_at: datetime | None
+
+
+class WebhookDeliveriesListResponse(BaseModel):
+    """Response model for list of webhook deliveries."""
+
+    results: list[WebhookDeliveryResponse]
+    total: int
+
+
+@router.get("/deliveries", response_model=WebhookDeliveriesListResponse)
+async def list_deliveries(
+    status: WebhookDeliveryStatus | None = Query(None, description="Filter by status"),
+    event_type: str | None = Query(None, description="Filter by event type"),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_session),
+) -> WebhookDeliveriesListResponse:
+    """List webhook deliveries with optional filtering."""
+    query = select(WebhookDeliveryDB)
+
+    if status:
+        query = query.where(WebhookDeliveryDB.status == status)
+    if event_type:
+        query = query.where(WebhookDeliveryDB.event_type == event_type)
+
+    # Get total count
+    count_query = select(WebhookDeliveryDB.id)
+    if status:
+        count_query = count_query.where(WebhookDeliveryDB.status == status)
+    if event_type:
+        count_query = count_query.where(WebhookDeliveryDB.event_type == event_type)
+    count_result = await session.execute(count_query)
+    total = len(count_result.all())
+
+    # Get paginated results
+    query = query.order_by(WebhookDeliveryDB.created_at.desc())
+    query = query.limit(limit).offset(offset)
+    result = await session.execute(query)
+    deliveries = result.scalars().all()
+
+    return WebhookDeliveriesListResponse(
+        results=[
+            WebhookDeliveryResponse(
+                id=d.id,
+                event_type=d.event_type,
+                payload=d.payload,
+                url=d.url,
+                status=d.status,
+                attempts=d.attempts,
+                last_attempt_at=d.last_attempt_at,
+                last_error=d.last_error,
+                last_status_code=d.last_status_code,
+                created_at=d.created_at,
+                delivered_at=d.delivered_at,
+            )
+            for d in deliveries
+        ],
+        total=total,
+    )
+
+
+@router.get("/deliveries/{delivery_id}", response_model=WebhookDeliveryResponse)
+async def get_delivery(
+    delivery_id: UUID,
+    session: AsyncSession = Depends(get_session),
+) -> WebhookDeliveryResponse:
+    """Get a specific webhook delivery by ID."""
+    result = await session.execute(
+        select(WebhookDeliveryDB).where(WebhookDeliveryDB.id == delivery_id)
+    )
+    delivery = result.scalar_one_or_none()
+    if not delivery:
+        from tessera.api.errors import NotFoundError
+
+        raise NotFoundError("Webhook delivery not found")
+
+    return WebhookDeliveryResponse(
+        id=delivery.id,
+        event_type=delivery.event_type,
+        payload=delivery.payload,
+        url=delivery.url,
+        status=delivery.status,
+        attempts=delivery.attempts,
+        last_attempt_at=delivery.last_attempt_at,
+        last_error=delivery.last_error,
+        last_status_code=delivery.last_status_code,
+        created_at=delivery.created_at,
+        delivered_at=delivery.delivered_at,
+    )

--- a/src/tessera/main.py
+++ b/src/tessera/main.py
@@ -9,7 +9,17 @@ from pydantic import ValidationError
 from sqlalchemy import text
 from starlette.exceptions import HTTPException
 
-from tessera.api import api_keys, assets, contracts, proposals, registrations, schemas, sync, teams
+from tessera.api import (
+    api_keys,
+    assets,
+    contracts,
+    proposals,
+    registrations,
+    schemas,
+    sync,
+    teams,
+    webhooks,
+)
 from tessera.api.errors import (
     APIError,
     RequestIDMiddleware,
@@ -67,6 +77,7 @@ api_v1.include_router(proposals.router, prefix="/proposals", tags=["proposals"])
 api_v1.include_router(schemas.router, prefix="/schemas", tags=["schemas"])
 api_v1.include_router(sync.router, prefix="/sync", tags=["sync"])
 api_v1.include_router(api_keys.router, prefix="/api-keys", tags=["api-keys"])
+api_v1.include_router(webhooks.router)
 
 app.include_router(api_v1)
 

--- a/src/tessera/models/enums.py
+++ b/src/tessera/models/enums.py
@@ -67,3 +67,11 @@ class APIKeyScope(StrEnum):
     READ = "read"  # GET endpoints, list/view operations
     WRITE = "write"  # POST/PUT/PATCH, create/update operations
     ADMIN = "admin"  # DELETE, API key management, team management
+
+
+class WebhookDeliveryStatus(StrEnum):
+    """Status of a webhook delivery attempt."""
+
+    PENDING = "pending"  # Queued for delivery
+    DELIVERED = "delivered"  # Successfully delivered (2xx response)
+    FAILED = "failed"  # Failed after all retries


### PR DESCRIPTION
## Summary
- Add `WebhookDeliveryDB` model to persist all webhook delivery attempts
- Add `WebhookDeliveryStatus` enum (pending, delivered, failed)
- Update webhook service to create delivery records and track status on success/failure
- Add `/api/v1/webhooks/deliveries` endpoint for querying delivery history
- Add `/api/v1/webhooks/deliveries/{id}` endpoint for individual delivery lookup

## Details
The retry logic with exponential backoff (1s, 5s, 30s delays) was already implemented. This PR adds the missing persistence layer so users can:
- Query delivery history with filters (status, event_type)
- Debug failed webhooks by checking last_error and last_status_code
- Track delivery success rates

## Test plan
- [x] All 168 tests pass
- [x] Linting passes (ruff check)

Fixes #88