### PR TITLE
Standardize API response formats for list endpoints

### DIFF
--- a/src/tessera/api/contracts.py
+++ b/src/tessera/api/contracts.py
@@ -133,11 +133,12 @@ async def get_contract(
     return contract
 
 
-@router.get("/{contract_id}/registrations", response_model=list[Registration])
+@router.get("/{contract_id}/registrations")
 async def list_contract_registrations(
     contract_id: UUID,
+    params: PaginationParams = Depends(pagination_params),
     session: AsyncSession = Depends(get_session),
-) -> list[RegistrationDB]:
+) -> dict[str, Any]:
     """List all registrations for a contract."""
     # Verify contract exists
     result = await session.execute(select(ContractDB).where(ContractDB.id == contract_id))
@@ -149,7 +150,5 @@ async def list_contract_registrations(
             details={"contract_id": str(contract_id)},
         )
 
-    reg_result = await session.execute(
-        select(RegistrationDB).where(RegistrationDB.contract_id == contract_id)
-    )
-    return list(reg_result.scalars().all())
+    query = select(RegistrationDB).where(RegistrationDB.contract_id == contract_id)
+    return await paginate(session, query, params, response_model=Registration)

--- a/src/tessera/cli/__init__.py
+++ b/src/tessera/cli/__init__.py
@@ -276,7 +276,8 @@ def contract_list(
 ) -> None:
     """List contracts for an asset."""
     response = make_request("GET", f"/assets/{asset_id}/contracts")
-    contracts = handle_response(response)
+    result = handle_response(response)
+    contracts = result.get("results", [])
 
     if not contracts:
         console.print("[dim]No contracts found[/dim]")

--- a/src/tessera/cli/dbt.py
+++ b/src/tessera/cli/dbt.py
@@ -281,7 +281,7 @@ def check(
                     # Try to publish (will create proposal for breaking change)
                     contracts_resp = make_request("GET", f"/assets/{asset_id}/contracts")
                     if contracts_resp.status_code == 200:
-                        contracts = contracts_resp.json()
+                        contracts = contracts_resp.json().get("results", [])
                         current = next((c for c in contracts if c["status"] == "active"), None)
                         if current:
                             # Increment version
@@ -459,7 +459,7 @@ def sync(
                         # Get current version and increment
                         contracts_resp = make_request("GET", f"/assets/{asset_id}/contracts")
                         if contracts_resp.status_code == 200:
-                            contracts = contracts_resp.json()
+                            contracts = contracts_resp.json().get("results", [])
                             current = next((c for c in contracts if c["status"] == "active"), None)
                             if current:
                                 v = current.get("version", "1.0.0")

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -341,8 +341,9 @@ class TestAssetDependencies:
         resp = await client.get(f"/api/v1/assets/{downstream_id}/dependencies")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["dependency_asset_id"] == upstream_id
+        assert data["total"] == 1
+        assert len(data["results"]) == 1
+        assert data["results"][0]["dependency_asset_id"] == upstream_id
 
     async def test_delete_dependency(self, client: AsyncClient):
         """Delete a dependency."""
@@ -370,7 +371,8 @@ class TestAssetDependencies:
 
         # Verify it's gone
         list_resp = await client.get(f"/api/v1/assets/{downstream_id}/dependencies")
-        assert len(list_resp.json()) == 0
+        assert list_resp.json()["total"] == 0
+        assert len(list_resp.json()["results"]) == 0
 
     async def test_self_dependency_fails(self, client: AsyncClient):
         """Asset cannot depend on itself."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,9 +146,7 @@ class TestAssetCommands:
     def test_asset_search(self) -> None:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "results": [{"id": "a1", "fqn": "db.schema.users"}]
-        }
+        mock_response.json.return_value = {"results": [{"id": "a1", "fqn": "db.schema.users"}]}
 
         with patch("tessera.cli.make_request", return_value=mock_response):
             result = runner.invoke(app, ["asset", "search", "users"])
@@ -219,7 +217,9 @@ class TestContractCommands:
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "proposal": {"id": "p1", "status": "pending"},
-            "breaking_changes": [{"change_type": "field_removed", "message": "Field 'name' removed"}],
+            "breaking_changes": [
+                {"change_type": "field_removed", "message": "Field 'name' removed"}
+            ],
         }
 
         with patch("tessera.cli.make_request", return_value=mock_response):
@@ -245,7 +245,7 @@ class TestContractCommands:
     def test_contract_list_empty(self) -> None:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.json.return_value = []
+        mock_response.json.return_value = {"results": [], "total": 0, "limit": 50, "offset": 0}
 
         with patch("tessera.cli.make_request", return_value=mock_response):
             result = runner.invoke(app, ["contract", "list", "asset-123"])
@@ -255,10 +255,25 @@ class TestContractCommands:
     def test_contract_list_with_contracts(self) -> None:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 200
-        mock_response.json.return_value = [
-            {"id": "c1", "version": "1.0.0", "status": "deprecated", "published_at": "2024-01-01T00:00:00Z"},
-            {"id": "c2", "version": "2.0.0", "status": "active", "published_at": "2024-01-02T00:00:00Z"},
-        ]
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "id": "c1",
+                    "version": "1.0.0",
+                    "status": "deprecated",
+                    "published_at": "2024-01-01T00:00:00Z",
+                },
+                {
+                    "id": "c2",
+                    "version": "2.0.0",
+                    "status": "active",
+                    "published_at": "2024-01-02T00:00:00Z",
+                },
+            ],
+            "total": 2,
+            "limit": 50,
+            "offset": 0,
+        }
 
         with patch("tessera.cli.make_request", return_value=mock_response):
             result = runner.invoke(app, ["contract", "list", "asset-123"])
@@ -274,7 +289,9 @@ class TestContractCommands:
             "to_version": "2.0.0",
             "change_type": "minor",
             "is_breaking": False,
-            "changes": [{"change_type": "field_added", "message": "Added field 'email'", "breaking": False}],
+            "changes": [
+                {"change_type": "field_added", "message": "Added field 'email'", "breaking": False}
+            ],
         }
 
         with patch("tessera.cli.make_request", return_value=mock_response):
@@ -347,7 +364,11 @@ class TestRegisterCommand:
     def test_register_success(self) -> None:
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 201
-        mock_response.json.return_value = {"id": "reg-1", "asset_id": "a1", "consumer_team_id": "t1"}
+        mock_response.json.return_value = {
+            "id": "reg-1",
+            "asset_id": "a1",
+            "consumer_team_id": "t1",
+        }
 
         with patch("tessera.cli.make_request", return_value=mock_response):
             result = runner.invoke(app, ["register", "--asset", "a1", "--team", "t1"])

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -182,9 +182,10 @@ class TestContractPublishing:
 
         resp = await client.get(f"/api/v1/assets/{asset_id}/contracts")
         assert resp.status_code == 200
-        contracts = resp.json()
-        assert len(contracts) == 1
-        assert contracts[0]["version"] == "1.0.0"
+        data = resp.json()
+        assert data["total"] == 1
+        assert len(data["results"]) == 1
+        assert data["results"][0]["version"] == "1.0.0"
 
 
 class TestContractsEndpoint:
@@ -285,5 +286,6 @@ class TestContractsEndpoint:
         resp = await client.get(f"/api/v1/contracts/{contract_id}/registrations")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["consumer_team_id"] == consumer_id
+        assert data["total"] == 1
+        assert len(data["results"]) == 1
+        assert data["results"][0]["consumer_team_id"] == consumer_id


### PR DESCRIPTION
## Summary

Standardizes all list endpoints to return consistent paginated response format.

Fixes #75

### Changes

**Endpoints updated to use pagination:**
- `GET /assets/{id}/contracts` - was returning `list[Contract]`
- `GET /assets/{id}/dependencies` - was returning `list[Dependency]`
- `GET /contracts/{id}/registrations` - was returning `list[Registration]`

**All list endpoints now return:**
```json
{
  "results": [...],
  "total": 100,
  "limit": 50,
  "offset": 0
}
```

**CLI updated:**
- `tessera contract list` now handles paginated response
- dbt sync commands updated to extract `results` from response

### Already Standardized (no changes needed)
- `GET /assets` - uses `paginate()`
- `GET /teams` - uses `paginate()`
- `GET /contracts` - uses `paginate()`
- `GET /proposals` - fixed in PR #94
- Error responses - already standardized in `errors.py`

## Test plan

- [x] All 168 tests pass
- [x] ruff check passes
- [x] mypy passes
- [x] CLI tests updated for new response format