### PR TITLE
Add CLI and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tessera
+# Tessera
 
 Data contract coordination for warehouses.
 
@@ -6,67 +6,121 @@ Data contract coordination for warehouses.
 
 Data contracts tell you something is wrong. They don't tell you what to do about it.
 
-The Kafka ecosystem solved producer/consumer coordination years ago with schema registries. Warehouses have nothing equivalent. When a producer wants to drop a column, rename a field, or change a type, the workflow is tribal knowledge: Slack threads, Confluence pages, and hope.
+The Kafka ecosystem solved producer/consumer coordination with schema registries. Warehouses have nothing equivalent. When a producer wants to drop a column, the workflow is tribal knowledge: Slack threads, Confluence pages, and hope.
 
-## What Tessera Does
+## How It Works
 
-Tessera is a coordination layer between data producers and consumers. It tracks:
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              TESSERA                                        │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  PRODUCER                          CONSUMER                                 │
+│  ────────                          ────────                                 │
+│                                                                             │
+│  1. Create Asset ──────────────────────────────────────────────────────┐    │
+│     (table, view, model)                                               │    │
+│                                                                        │    │
+│  2. Publish Contract ──────────┐                                       │    │
+│     (schema + guarantees)      │                                       │    │
+│                                ▼                                       │    │
+│                         ┌────────────┐                                 │    │
+│                         │  CONTRACT  │◄───── 3. Register ──────────────┘    │
+│                         │   v1.0.0   │       (declare dependency)           │
+│                         └────────────┘                                      │
+│                                                                             │
+│  4. Breaking Change ───────────┐                                            │
+│     (drop column, change type) │                                            │
+│                                ▼                                            │
+│                         ┌────────────┐                                      │
+│                         │  PROPOSAL  │──────► 5. Notify ──────────────┐     │
+│                         │  (pending) │        (affected consumers)    │     │
+│                         └────────────┘                                │     │
+│                                ▲                                      │     │
+│                                │                                      ▼     │
+│                                └─────────── 6. Acknowledge ───────────┘     │
+│                                             (approve/block/migrate)         │
+│                                                                             │
+│  7. Publish v2.0.0 ◄─────── (all acknowledged)                              │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
 
-- **Who owns what**: Explicit ownership of tables, views, and models
-- **Who depends on what**: Consumers register their dependencies
-- **What's changing**: Producers propose schema changes
-- **Who's affected**: Impact analysis before deploy
-- **Who's acknowledged**: Breaking changes require consumer sign-off
+**Producers** own assets and publish versioned contracts (JSON Schema + guarantees).
 
-## Core Concepts
+**Consumers** register dependencies on contracts they use.
 
-**Asset**: A data object (table, view, dbt model) with an owner.
-
-**Contract**: A versioned schema plus guarantees—freshness, volume bounds, nullability, accepted values.
-
-**Registration**: A consumer declaring "I depend on this contract."
-
-**Proposal**: A producer requesting a breaking change. Triggers notifications to affected consumers.
-
-**Acknowledgment**: A consumer responding to a proposal—approved, blocked, or migrating.
-
-## The Name
-
-In ancient Rome, a *tessera* was a token split between two parties to prove identity or agreement. Each half was meaningless alone. Matching edges proved the agreement was valid.
-
-That's the producer/consumer relationship. Neither side works alone. Tessera makes the agreement explicit.
-
-## Database Support
-
-**PostgreSQL** (Recommended for production)
-- Full support with schemas: `core`, `workflow`, `audit`
-- Use Alembic migrations: `alembic upgrade head`
-
-**SQLite** (Testing only)
-- Supported for unit tests via in-memory databases
-- Set `DATABASE_URL=sqlite+aiosqlite:///:memory:`
-- Tables created without schema prefixes
-- Not recommended for production
+**Breaking changes** create proposals that block until affected consumers acknowledge.
 
 ## Quick Start
 
 ```bash
-# Install dependencies
+# Install
 uv sync --all-extras
 
-# Set up environment
+# Configure
 cp .env.example .env
-# Edit .env with your DATABASE_URL
+# Edit DATABASE_URL
 
-# Run migrations
-alembic upgrade head
-
-# Start the server
+# Run
 uv run uvicorn tessera.main:app --reload
 
-# Run tests
+# Test
 DATABASE_URL=sqlite+aiosqlite:///:memory: uv run pytest
 ```
+
+## CLI
+
+```bash
+tessera team create --name "Analytics" --slug analytics
+tessera asset create --team <id> --fqn warehouse.core.users --type table
+tessera contract publish --asset <id> --schema @schema.json
+tessera register --asset <id> --team <consumer-id>
+tessera proposal acknowledge <id> --team <id> --response approved
+```
+
+Full reference: [docs/cli.md](docs/cli.md)
+
+## API
+
+All endpoints under `/api/v1`. Interactive docs at `/docs`.
+
+| Resource | Endpoints |
+|----------|-----------|
+| Teams | CRUD + restore |
+| Assets | CRUD + restore, dependencies, lineage |
+| Contracts | Publish, list, diff, impact analysis |
+| Registrations | CRUD (consumer dependencies) |
+| Proposals | List, acknowledge, withdraw, force, publish |
+| Sync | Push/pull state, dbt manifest sync |
+| Admin | API keys, webhooks, audit trail |
+
+Full reference: [docs/api.md](docs/api.md)
+
+## Compatibility Modes
+
+| Mode | Breaking if... |
+|------|----------------|
+| `backward` | Remove field, add required, narrow type |
+| `forward` | Add field, remove required, widen type |
+| `full` | Any schema change |
+| `none` | Nothing (notify only) |
+
+## Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | PostgreSQL or SQLite connection string |
+| `AUTH_DISABLED` | Skip auth for development (`true`/`false`) |
+| `BOOTSTRAP_API_KEY` | Initial admin key for setup |
+| `ENVIRONMENT` | `development` or `production` |
+| `CORS_ORIGINS` | Allowed origins (comma-separated) |
+
+## Database
+
+**PostgreSQL** (production): Full support with migrations via Alembic.
+
+**SQLite** (development): `DATABASE_URL=sqlite+aiosqlite:///:memory:`
 
 ## Status
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,139 @@
+# API Reference
+
+Base URL: `/api/v1`
+
+Interactive docs available at `/docs` (Swagger) and `/redoc` (ReDoc).
+
+## Authentication
+
+All endpoints require an API key via `X-API-Key` header.
+
+Scopes: `read`, `write`, `admin`
+
+## Teams
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/teams` | Create team | write |
+| GET | `/teams` | List teams | read |
+| GET | `/teams/{id}` | Get team | read |
+| PATCH | `/teams/{id}` | Update team | write |
+| DELETE | `/teams/{id}` | Soft delete team | write |
+| POST | `/teams/{id}/restore` | Restore deleted team | write |
+
+## Assets
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/assets` | Create asset | write |
+| GET | `/assets` | List assets | read |
+| GET | `/assets/search` | Search by FQN | read |
+| GET | `/assets/{id}` | Get asset | read |
+| PATCH | `/assets/{id}` | Update asset | write |
+| DELETE | `/assets/{id}` | Soft delete asset | write |
+| POST | `/assets/{id}/restore` | Restore deleted asset | write |
+
+### Contracts
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/assets/{id}/contracts` | Publish contract | write |
+| GET | `/assets/{id}/contracts` | List contracts | read |
+| GET | `/assets/{id}/contracts/history` | Version history | read |
+| GET | `/assets/{id}/contracts/diff` | Compare versions | read |
+| POST | `/assets/{id}/impact` | Impact analysis | read |
+
+### Dependencies
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/assets/{id}/dependencies` | Add dependency | write |
+| GET | `/assets/{id}/dependencies` | List dependencies | read |
+| DELETE | `/assets/{id}/dependencies/{dep_id}` | Remove dependency | write |
+| GET | `/assets/{id}/lineage` | Get lineage graph | read |
+
+## Registrations
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/registrations` | Register as consumer | write |
+| GET | `/registrations` | List registrations | read |
+| GET | `/registrations/{id}` | Get registration | read |
+| PATCH | `/registrations/{id}` | Update registration | write |
+| DELETE | `/registrations/{id}` | Unregister | write |
+
+## Proposals
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| GET | `/proposals` | List proposals | read |
+| GET | `/proposals/{id}` | Get proposal | read |
+| GET | `/proposals/{id}/status` | Acknowledgment status | read |
+| POST | `/proposals/{id}/acknowledge` | Submit acknowledgment | write |
+| POST | `/proposals/{id}/withdraw` | Withdraw proposal | write |
+| POST | `/proposals/{id}/force` | Force approve | admin |
+| POST | `/proposals/{id}/publish` | Publish approved proposal | write |
+
+## Sync
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/sync/push` | Push schema state | write |
+| POST | `/sync/pull` | Pull registered contracts | read |
+| POST | `/sync/dbt` | Sync from dbt manifest | write |
+| POST | `/sync/dbt/impact` | Analyze dbt manifest changes | read |
+
+## Schemas
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/schemas/validate` | Validate JSON Schema | read |
+
+## API Keys (Admin)
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| POST | `/api-keys` | Create API key | admin |
+| GET | `/api-keys` | List API keys | admin |
+| GET | `/api-keys/{id}` | Get API key | admin |
+| DELETE | `/api-keys/{id}` | Revoke API key | admin |
+
+## Webhooks (Admin)
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| GET | `/webhooks/deliveries` | List deliveries | admin |
+| GET | `/webhooks/deliveries/{id}` | Get delivery | admin |
+
+## Audit (Admin)
+
+| Method | Endpoint | Description | Scope |
+|--------|----------|-------------|-------|
+| GET | `/audit/events` | Query audit events | admin |
+| GET | `/audit/events/{id}` | Get audit event | admin |
+| GET | `/audit/entities/{type}/{id}/history` | Entity history | admin |
+
+## Health
+
+| Method | Endpoint | Description | Auth |
+|--------|----------|-------------|------|
+| GET | `/health` | Basic health check | None |
+| GET | `/health/ready` | Readiness (DB check) | None |
+| GET | `/health/live` | Liveness probe | None |
+
+## Error Responses
+
+All errors return:
+
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable message",
+    "details": {}
+  },
+  "request_id": "uuid"
+}
+```
+
+Common codes: `VALIDATION_ERROR`, `NOT_FOUND`, `CONFLICT`, `UNAUTHORIZED`, `FORBIDDEN`, `RATE_LIMIT_EXCEEDED`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,265 @@
+# CLI Reference
+
+Tessera provides a command-line interface for managing data contracts.
+
+## Installation
+
+```bash
+uv sync --all-extras
+```
+
+## Commands
+
+### `tessera serve`
+
+Start the API server.
+
+```bash
+tessera serve --host 0.0.0.0 --port 8000
+```
+
+### `tessera version`
+
+Show Tessera version.
+
+---
+
+## Team Management
+
+### `tessera team create`
+
+Create a new team.
+
+```bash
+tessera team create --name "Data Platform" --slug data-platform
+```
+
+### `tessera team list`
+
+List all teams.
+
+```bash
+tessera team list
+```
+
+### `tessera team get`
+
+Get team details.
+
+```bash
+tessera team get <team-id>
+```
+
+---
+
+## Asset Management
+
+### `tessera asset create`
+
+Create a new asset.
+
+```bash
+tessera asset create \
+  --team <team-id> \
+  --fqn warehouse.schema.table \
+  --type table
+```
+
+### `tessera asset list`
+
+List assets with optional filters.
+
+```bash
+tessera asset list --team <team-id>
+```
+
+### `tessera asset get`
+
+Get asset details.
+
+```bash
+tessera asset get <asset-id>
+```
+
+### `tessera asset search`
+
+Search assets by fully-qualified name.
+
+```bash
+tessera asset search --fqn warehouse.schema.%
+```
+
+---
+
+## Contract Management
+
+### `tessera contract publish`
+
+Publish a new contract version.
+
+```bash
+tessera contract publish \
+  --asset <asset-id> \
+  --schema @schema.json \
+  --compatibility backward
+```
+
+Options:
+- `--compatibility`: `backward` (default), `forward`, `full`, `none`
+- `--force`: Skip breaking change workflow
+
+### `tessera contract list`
+
+List contracts for an asset.
+
+```bash
+tessera contract list --asset <asset-id>
+```
+
+### `tessera contract diff`
+
+Show differences between contract versions.
+
+```bash
+tessera contract diff --asset <asset-id> --from v1 --to v2
+```
+
+### `tessera contract impact`
+
+Analyze impact of a proposed schema change.
+
+```bash
+tessera contract impact --asset <asset-id> --schema @new-schema.json
+```
+
+---
+
+## Consumer Registration
+
+### `tessera register`
+
+Register as a consumer of an asset.
+
+```bash
+tessera register --asset <asset-id> --team <consumer-team-id>
+```
+
+Options:
+- `--pin`: Pin to a specific contract version
+
+---
+
+## Proposal Management
+
+### `tessera proposal list`
+
+List breaking change proposals.
+
+```bash
+tessera proposal list --asset <asset-id> --status pending
+```
+
+### `tessera proposal get`
+
+Get proposal details.
+
+```bash
+tessera proposal get <proposal-id>
+```
+
+### `tessera proposal status`
+
+Get proposal acknowledgment status.
+
+```bash
+tessera proposal status <proposal-id>
+```
+
+### `tessera proposal acknowledge`
+
+Acknowledge a breaking change proposal.
+
+```bash
+tessera proposal acknowledge <proposal-id> \
+  --team <team-id> \
+  --response approved
+```
+
+Responses: `approved`, `blocked`, `will_migrate`
+
+### `tessera proposal withdraw`
+
+Withdraw a pending proposal.
+
+```bash
+tessera proposal withdraw <proposal-id>
+```
+
+### `tessera proposal force`
+
+Force approve a proposal (skips consumer acknowledgment).
+
+```bash
+tessera proposal force <proposal-id>
+```
+
+### `tessera proposal publish`
+
+Publish an approved proposal as a new contract.
+
+```bash
+tessera proposal publish <proposal-id>
+```
+
+---
+
+## dbt Integration
+
+### `tessera dbt sync`
+
+Sync dbt models with Tessera.
+
+```bash
+tessera dbt sync --manifest target/manifest.json --team <team-id>
+```
+
+### `tessera dbt check`
+
+Check dbt models for schema changes against registered contracts.
+
+```bash
+tessera dbt check --manifest target/manifest.json
+```
+
+### `tessera dbt register`
+
+Register as a consumer of upstream dependencies.
+
+```bash
+tessera dbt register --manifest target/manifest.json --team <team-id>
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TESSERA_API_URL` | API server URL | `http://localhost:8000` |
+| `TESSERA_API_KEY` | API key for authentication | - |
+| `DATABASE_URL` | Database connection string | - |
+
+---
+
+## Shell Completion
+
+```bash
+# Bash
+tessera --install-completion bash
+
+# Zsh
+tessera --install-completion zsh
+
+# Fish
+tessera --install-completion fish
+```


### PR DESCRIPTION
## Summary

- Create `docs/` folder with detailed CLI and API reference documentation
- Update README with ASCII architecture diagram showing producer/consumer flow
- Add summary tables for API endpoints and CLI commands
- Keep README tight by moving detailed references to docs/

## Changes

- `docs/cli.md`: Full CLI reference with all commands and options
- `docs/api.md`: Complete API reference with all endpoints, methods, and scopes
- `README.md`: Streamlined with diagram, quick start, and links to detailed docs

## Test plan

- [x] Verify docs/ files render correctly on GitHub
- [x] Check README diagram displays properly
- [x] Ensure all links work