### PR TITLE
Fix docs password and add missing DB model exports

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -29,7 +29,7 @@ Open [http://localhost:8000](http://localhost:8000) in your browser.
 
 Default credentials:
 - **Email**: `admin@example.com`
-- **Password**: `admin123`
+- **Password**: `admin`
 
 ## Create Your First Contract
 

--- a/src/tessera/db/__init__.py
+++ b/src/tessera/db/__init__.py
@@ -3,6 +3,7 @@
 from tessera.db.database import get_session, init_db
 from tessera.db.models import (
     AcknowledgmentDB,
+    APIKeyDB,
     AssetDB,
     AssetDependencyDB,
     AuditEventDB,
@@ -13,6 +14,7 @@ from tessera.db.models import (
     RegistrationDB,
     TeamDB,
     UserDB,
+    WebhookDeliveryDB,
 )
 
 __all__ = [
@@ -29,4 +31,6 @@ __all__ = [
     "AcknowledgmentDB",
     "AuditEventDB",
     "AuditRunDB",
+    "APIKeyDB",
+    "WebhookDeliveryDB",
 ]


### PR DESCRIPTION
## Summary
- Fix default password in quickstart docs: `admin123` → `admin`
- Export `APIKeyDB` and `WebhookDeliveryDB` from `tessera.db` module (these models existed but weren't exported)

## Test plan
- [x] ruff check passes
- [x] mypy passes
- [x] Pre-commit hooks pass