### PR TITLE
Fix outdated CLI commands and Docker image references in docs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -37,7 +37,7 @@ export DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/tessera"
 export SECRET_KEY="your-secret-key-here"
 
 # Run database migrations
-tessera db upgrade
+alembic upgrade head
 
 # Start the server
 tessera serve
@@ -76,14 +76,14 @@ Tessera supports:
 createdb tessera
 
 # Run migrations
-DATABASE_URL=postgresql+asyncpg://localhost/tessera tessera db upgrade
+DATABASE_URL=postgresql+asyncpg://localhost/tessera alembic upgrade head
 ```
 
 ### SQLite Setup (Development)
 
 ```bash
 # SQLite works out of the box
-DATABASE_URL=sqlite+aiosqlite:///./tessera.db tessera db upgrade
+DATABASE_URL=sqlite+aiosqlite:///./tessera.db alembic upgrade head
 ```
 
 ## Verify Installation

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -22,7 +22,7 @@ This starts:
 # docker-compose.yml
 services:
   api:
-    image: ghcr.io/ashita-ai/tessera:latest
+    build: .
     ports:
       - "8000:8000"
     environment:
@@ -56,7 +56,7 @@ volumes:
 ```yaml
 services:
   api:
-    image: ghcr.io/ashita-ai/tessera:latest
+    build: .
     environment:
       - DATABASE_URL=postgresql+asyncpg://tessera:tessera@db:5432/tessera
       - REDIS_URL=redis://redis:6379/0
@@ -89,7 +89,9 @@ volumes:
 ```yaml
 services:
   api:
-    image: ghcr.io/ashita-ai/tessera:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
     deploy:
       replicas: 3
       resources:
@@ -141,7 +143,7 @@ docker compose -f docker-compose.yml up -d
 Migrations run automatically on startup. To run manually:
 
 ```bash
-docker compose exec api tessera db upgrade
+docker compose exec api alembic upgrade head
 ```
 
 ## Logs
@@ -173,7 +175,4 @@ cat backup.sql | docker compose exec -T db psql -U tessera tessera
 ```bash
 # API health
 curl http://localhost:8000/health
-
-# Database connectivity
-docker compose exec api tessera db check
 ```


### PR DESCRIPTION
## Summary
- Replace `tessera db upgrade` with `alembic upgrade head` (the `tessera db` CLI subcommand doesn't exist)
- Remove `tessera db check` command reference
- Update Docker compose examples to use `build: .` instead of non-existent `ghcr.io/ashita-ai/tessera` image
- Use `Dockerfile.prod` for production setup example

## Test plan
- [x] Verified CLI commands against actual `tessera --help` output
- [x] Commands now match what's actually available