### PR TITLE
Update example dates from 2024 to 2025 in docs

### DIFF
--- a/docs/api/assets.md
+++ b/docs/api/assets.md
@@ -29,7 +29,7 @@ GET /api/v1/assets
       "owner_team_id": "team-uuid",
       "owner_team_name": "Data Platform",
       "environment": "production",
-      "created_at": "2024-01-15T10:00:00Z",
+      "created_at": "2025-01-15T10:00:00Z",
       "active_contract_id": "contract-uuid",
       "active_contract_version": "1.2.0"
     }
@@ -62,8 +62,8 @@ GET /api/v1/assets/{asset_id}
     "description": "Core users table",
     "tags": ["pii", "core"]
   },
-  "created_at": "2024-01-15T10:00:00Z",
-  "updated_at": "2024-01-20T15:30:00Z"
+  "created_at": "2025-01-15T10:00:00Z",
+  "updated_at": "2025-01-20T15:30:00Z"
 }
 ```
 
@@ -95,7 +95,7 @@ POST /api/v1/assets
   "fqn": "warehouse.analytics.users",
   "owner_team_id": "team-uuid",
   "environment": "production",
-  "created_at": "2024-01-15T10:00:00Z"
+  "created_at": "2025-01-15T10:00:00Z"
 }
 ```
 

--- a/docs/api/contracts.md
+++ b/docs/api/contracts.md
@@ -29,7 +29,7 @@ GET /api/v1/contracts
       "version": "1.2.0",
       "status": "active",
       "compatibility_mode": "backward",
-      "published_at": "2024-01-15T10:00:00Z",
+      "published_at": "2025-01-15T10:00:00Z",
       "published_by": "team-uuid",
       "published_by_team_name": "Data Platform"
     }
@@ -70,7 +70,7 @@ GET /api/v1/contracts/{contract_id}
       "id": "not_null"
     }
   },
-  "published_at": "2024-01-15T10:00:00Z",
+  "published_at": "2025-01-15T10:00:00Z",
   "published_by": "team-uuid"
 }
 ```
@@ -92,7 +92,7 @@ List all consumer registrations for a contract.
       "id": "registration-uuid",
       "consumer_team_id": "team-uuid",
       "consumer_team_name": "Analytics",
-      "registered_at": "2024-01-10T10:00:00Z",
+      "registered_at": "2025-01-10T10:00:00Z",
       "status": "active"
     }
   ]

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -33,7 +33,7 @@ All responses are JSON:
 {
   "id": "uuid",
   "field": "value",
-  "created_at": "2024-01-15T10:30:00Z"
+  "created_at": "2025-01-15T10:30:00Z"
 }
 ```
 

--- a/docs/api/proposals.md
+++ b/docs/api/proposals.md
@@ -31,7 +31,7 @@ GET /api/v1/proposals
       "breaking_changes_count": 2,
       "total_consumers": 3,
       "acknowledgment_count": 1,
-      "proposed_at": "2024-01-15T10:00:00Z",
+      "proposed_at": "2025-01-15T10:00:00Z",
       "proposed_by": "team-uuid"
     }
   ]
@@ -66,7 +66,7 @@ GET /api/v1/proposals/{proposal_id}
       "team_id": "team-uuid",
       "team_name": "Analytics",
       "acknowledged": true,
-      "acknowledged_at": "2024-01-16T10:00:00Z",
+      "acknowledged_at": "2025-01-16T10:00:00Z",
       "notes": "Updated our dashboards"
     },
     {
@@ -75,7 +75,7 @@ GET /api/v1/proposals/{proposal_id}
       "acknowledged": false
     }
   ],
-  "proposed_at": "2024-01-15T10:00:00Z",
+  "proposed_at": "2025-01-15T10:00:00Z",
   "proposed_by": "team-uuid"
 }
 ```
@@ -101,7 +101,7 @@ Acknowledge that your team is ready for the breaking change.
 ```json
 {
   "acknowledged": true,
-  "acknowledged_at": "2024-01-16T10:00:00Z",
+  "acknowledged_at": "2025-01-16T10:00:00Z",
   "remaining_consumers": 1
 }
 ```

--- a/docs/api/teams.md
+++ b/docs/api/teams.md
@@ -16,7 +16,7 @@ GET /api/v1/teams
     {
       "id": "team-uuid",
       "name": "data-platform",
-      "created_at": "2024-01-01T10:00:00Z",
+      "created_at": "2025-01-01T10:00:00Z",
       "member_count": 5,
       "asset_count": 25
     }
@@ -36,7 +36,7 @@ GET /api/v1/teams/{team_id}
 {
   "id": "team-uuid",
   "name": "data-platform",
-  "created_at": "2024-01-01T10:00:00Z",
+  "created_at": "2025-01-01T10:00:00Z",
   "members": [
     {
       "id": "user-uuid",
@@ -68,7 +68,7 @@ POST /api/v1/teams
 {
   "id": "new-team-uuid",
   "name": "analytics",
-  "created_at": "2024-01-15T10:00:00Z"
+  "created_at": "2025-01-15T10:00:00Z"
 }
 ```
 
@@ -137,7 +137,7 @@ POST /api/v1/teams/{team_id}/api-keys
   "key": "tsk_abc123...",
   "key_prefix": "tsk_abc1",
   "scopes": ["read", "write"],
-  "created_at": "2024-01-15T10:00:00Z"
+  "created_at": "2025-01-15T10:00:00Z"
 }
 ```
 

--- a/docs/concepts/consumer-registration.md
+++ b/docs/concepts/consumer-registration.md
@@ -85,7 +85,7 @@ Response:
     {
       "team_id": "team-uuid",
       "team_name": "Analytics",
-      "registration_date": "2024-01-15"
+      "registration_date": "2025-01-15"
     }
   ],
   "total_affected": 3


### PR DESCRIPTION
## Summary
Update all example timestamps in documentation from 2024 to 2025.

Files updated:
- `docs/api/assets.md`
- `docs/api/contracts.md`
- `docs/api/overview.md`
- `docs/api/proposals.md`
- `docs/api/teams.md`
- `docs/concepts/consumer-registration.md`

## Test plan
- [x] No 2024 dates remain in docs/