### PR TITLE
Add OpenAPI and GraphQL integration documentation

### DIFF
--- a/docs/guides/graphql-integration.md
+++ b/docs/guides/graphql-integration.md
@@ -1,0 +1,257 @@
+# GraphQL Integration
+
+Tessera can import contracts from GraphQL schemas via introspection, creating assets for each query and mutation.
+
+## Overview
+
+The integration:
+
+1. Parses a GraphQL introspection response
+2. Creates assets for each query and mutation
+3. Extracts argument and return type schemas as contracts
+4. Tracks schema changes across versions
+
+## Endpoint
+
+**POST /api/v1/sync/graphql**
+
+Requires `admin` scope.
+
+## Request
+
+```json
+{
+  "introspection": { /* GraphQL introspection response */ },
+  "schema_name": "My GraphQL API",
+  "owner_team_id": "uuid",
+  "environment": "production",
+  "auto_publish_contracts": true,
+  "dry_run": false
+}
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `introspection` | object | required | GraphQL introspection response (`__schema` or `data.__schema`) |
+| `schema_name` | string | `"GraphQL API"` | Name for the schema (used in FQN generation) |
+| `owner_team_id` | UUID | required | Team that will own the imported assets |
+| `environment` | string | `"production"` | Environment for assets |
+| `auto_publish_contracts` | boolean | `true` | Automatically publish contracts for new assets |
+| `dry_run` | boolean | `false` | Preview changes without creating assets |
+
+## Response
+
+```json
+{
+  "schema_name": "My GraphQL API",
+  "operations_found": 12,
+  "assets_created": 8,
+  "assets_updated": 4,
+  "assets_skipped": 0,
+  "contracts_published": 8,
+  "operations": [
+    {
+      "fqn": "graphql.production.my_graphql_api.query.users",
+      "operation_name": "users",
+      "operation_type": "query",
+      "action": "created",
+      "asset_id": "uuid",
+      "contract_id": "uuid"
+    }
+  ],
+  "parse_errors": []
+}
+```
+
+## Getting the Introspection Response
+
+Run the standard introspection query against your GraphQL endpoint:
+
+```graphql
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    types {
+      kind name description
+      fields {
+        name description
+        args { name type { ...TypeRef } }
+        type { ...TypeRef }
+      }
+      inputFields { name type { ...TypeRef } }
+      enumValues { name description }
+      possibleTypes { name }
+    }
+  }
+}
+
+fragment TypeRef on __Type {
+  kind name
+  ofType {
+    kind name
+    ofType {
+      kind name
+      ofType { kind name }
+    }
+  }
+}
+```
+
+Save the response and use it with Tessera:
+
+```bash
+# Get introspection from your GraphQL endpoint
+curl -X POST https://api.example.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ __schema { queryType { name } mutationType { name } types { kind name fields { name args { name type { kind name ofType { kind name } } } type { kind name ofType { kind name } } } } } }"}' \
+  > introspection.json
+```
+
+## Quick Start
+
+```bash
+# Import from GraphQL introspection
+curl -X POST http://localhost:8000/api/v1/sync/graphql \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"introspection\": $(cat introspection.json),
+    \"schema_name\": \"Users API\",
+    \"owner_team_id\": \"$TEAM_ID\",
+    \"auto_publish_contracts\": true
+  }"
+```
+
+## Dry Run
+
+Preview what would be imported without creating assets:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/sync/graphql \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"introspection\": $(cat introspection.json),
+    \"schema_name\": \"Users API\",
+    \"owner_team_id\": \"$TEAM_ID\",
+    \"dry_run\": true
+  }"
+```
+
+## What Gets Imported
+
+### Asset FQN Format
+
+Each query/mutation becomes an asset with FQN:
+
+```
+graphql.{environment}.{schema_name}.{type}.{operation_name}
+```
+
+Examples:
+- `graphql.production.users_api.query.users`
+- `graphql.production.users_api.query.user`
+- `graphql.production.users_api.mutation.createUser`
+- `graphql.staging.orders_api.mutation.cancelOrder`
+
+### Contract Schema
+
+The contract schema captures arguments and return types:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "arguments": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "limit": { "type": "integer" }
+      },
+      "required": ["id"]
+    },
+    "return_type": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "email": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+### Resource Type
+
+All imported assets have `resource_type: "graphql_query"`.
+
+## Python SDK
+
+```python
+from tessera_sdk import TesseraClient
+import json
+
+client = TesseraClient(base_url="http://localhost:8000")
+
+# Load introspection response
+with open("introspection.json") as f:
+    introspection = json.load(f)
+
+# Import to Tessera
+result = client.sync.graphql(
+    introspection=introspection,
+    schema_name="Users API",
+    owner_team_id="your-team-uuid",
+    auto_publish_contracts=True
+)
+
+print(f"Created {result.assets_created} assets")
+print(f"Published {result.contracts_published} contracts")
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Sync GraphQL Schema to Tessera
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'schema.graphql'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get introspection
+        run: |
+          curl -X POST ${{ secrets.GRAPHQL_ENDPOINT }} \
+            -H "Content-Type: application/json" \
+            -d '{"query": "{ __schema { queryType { name } mutationType { name } types { kind name fields { name args { name type { kind name ofType { kind name } } } type { kind name ofType { kind name } } } } } }"}' \
+            > introspection.json
+
+      - name: Sync to Tessera
+        run: |
+          curl -X POST ${{ secrets.TESSERA_URL }}/api/v1/sync/graphql \
+            -H "Authorization: Bearer ${{ secrets.TESSERA_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"introspection\": $(cat introspection.json),
+              \"schema_name\": \"My API\",
+              \"owner_team_id\": \"${{ secrets.TESSERA_TEAM_ID }}\",
+              \"auto_publish_contracts\": true
+            }"
+```
+
+## Limitations
+
+- Only queries and mutations are imported (subscriptions are not yet supported)
+- The introspection must include type details (not just type names)
+- No dedicated impact/diff endpoints yet (use `dry_run: true` to preview)

--- a/docs/guides/openapi-integration.md
+++ b/docs/guides/openapi-integration.md
@@ -1,0 +1,255 @@
+# OpenAPI Integration
+
+Tessera can import contracts from OpenAPI 3.x specifications, creating assets for each API endpoint.
+
+## Overview
+
+The integration:
+
+1. Parses your OpenAPI spec (JSON or YAML converted to JSON)
+2. Creates assets for each endpoint (method + path)
+3. Extracts request/response schemas as contracts
+4. Tracks schema changes across versions
+
+## Endpoint
+
+**POST /api/v1/sync/openapi**
+
+Requires `admin` scope.
+
+## Request
+
+```json
+{
+  "spec": { /* OpenAPI 3.x specification */ },
+  "owner_team_id": "uuid",
+  "environment": "production",
+  "auto_publish_contracts": true,
+  "dry_run": false
+}
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `spec` | object | required | OpenAPI 3.x specification as JSON |
+| `owner_team_id` | UUID | required | Team that will own the imported assets |
+| `environment` | string | `"production"` | Environment for assets |
+| `auto_publish_contracts` | boolean | `true` | Automatically publish contracts for new assets |
+| `dry_run` | boolean | `false` | Preview changes without creating assets |
+
+## Response
+
+```json
+{
+  "api_title": "My API",
+  "api_version": "1.0.0",
+  "endpoints_found": 15,
+  "assets_created": 10,
+  "assets_updated": 5,
+  "assets_skipped": 0,
+  "contracts_published": 10,
+  "endpoints": [
+    {
+      "fqn": "api.production.GET./users",
+      "path": "/users",
+      "method": "GET",
+      "action": "created",
+      "asset_id": "uuid",
+      "contract_id": "uuid"
+    }
+  ],
+  "parse_errors": []
+}
+```
+
+## Quick Start
+
+```bash
+# Import from OpenAPI spec
+curl -X POST http://localhost:8000/api/v1/sync/openapi \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"spec\": $(cat openapi.json),
+    \"owner_team_id\": \"$TEAM_ID\",
+    \"auto_publish_contracts\": true
+  }"
+```
+
+## Dry Run
+
+Preview what would be imported without creating assets:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/sync/openapi \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"spec\": $(cat openapi.json),
+    \"owner_team_id\": \"$TEAM_ID\",
+    \"dry_run\": true
+  }"
+```
+
+The response will show `action: "would_create"` or `action: "would_update"` instead of actually making changes.
+
+## What Gets Imported
+
+### Asset FQN Format
+
+Each endpoint becomes an asset with FQN:
+
+```
+api.{environment}.{METHOD}.{path}
+```
+
+Examples:
+- `api.production.GET./users`
+- `api.production.POST./users/{id}`
+- `api.staging.DELETE./orders/{orderId}`
+
+### Contract Schema
+
+The contract schema combines request and response schemas:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "request": {
+      "parameters": { /* path, query, header params */ },
+      "body": { /* request body schema */ }
+    },
+    "response": {
+      "200": { /* success response schema */ },
+      "400": { /* error response schema */ }
+    }
+  }
+}
+```
+
+### Resource Type
+
+All imported assets have `resource_type: "api_endpoint"`.
+
+## Example OpenAPI Spec
+
+```json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Users API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "List users",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer" },
+                      "name": { "type": "string" },
+                      "email": { "type": "string" }
+                    },
+                    "required": ["id", "name"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "email": { "type": "string" }
+                },
+                "required": ["name", "email"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Python SDK
+
+```python
+from tessera_sdk import TesseraClient
+import json
+
+client = TesseraClient(base_url="http://localhost:8000")
+
+# Load OpenAPI spec
+with open("openapi.json") as f:
+    spec = json.load(f)
+
+# Import to Tessera
+result = client.sync.openapi(
+    spec=spec,
+    owner_team_id="your-team-uuid",
+    auto_publish_contracts=True
+)
+
+print(f"Created {result.assets_created} assets")
+print(f"Published {result.contracts_published} contracts")
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Sync OpenAPI to Tessera
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'openapi.json'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync to Tessera
+        run: |
+          curl -X POST ${{ secrets.TESSERA_URL }}/api/v1/sync/openapi \
+            -H "Authorization: Bearer ${{ secrets.TESSERA_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"spec\": $(cat openapi.json),
+              \"owner_team_id\": \"${{ secrets.TESSERA_TEAM_ID }}\",
+              \"auto_publish_contracts\": true
+            }"
+```
+
+## Limitations
+
+- Only OpenAPI 3.x is supported (not Swagger 2.0)
+- The spec must be provided as JSON (convert YAML first)
+- No dedicated impact/diff endpoints yet (use `dry_run: true` to preview)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,8 @@ nav:
   - Guides:
     - Python SDK: guides/python-sdk.md
     - dbt Integration: guides/dbt-integration.md
+    - OpenAPI Integration: guides/openapi-integration.md
+    - GraphQL Integration: guides/graphql-integration.md
     - CI/CD Integration: guides/ci-cd.md
     - Docker Deployment: guides/docker.md
   - API Reference:


### PR DESCRIPTION
## Summary

Adds documentation for the OpenAPI and GraphQL sync integrations.

**New files:**
- `docs/guides/openapi-integration.md` - OpenAPI 3.x spec import
- `docs/guides/graphql-integration.md` - GraphQL introspection import

**Updated files:**
- `mkdocs.yml` - Added navigation entries

## Documentation Coverage

Each guide includes:
- Endpoint reference with request/response examples
- Quick start with curl examples
- Dry run mode for previewing changes
- What gets imported (FQN format, schema structure, resource types)
- Python SDK usage
- CI/CD integration examples
- Limitations

## Note

Both docs mention that impact/diff endpoints are not yet available (use `dry_run: true` instead). This could be a future enhancement for feature parity with dbt.