### PR TITLE
Add guarantees support for OpenAPI and GraphQL integrations

### DIFF
--- a/.github/actions/dbt-check/action.yml
+++ b/.github/actions/dbt-check/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Install Tessera CLI
       shell: bash
       run: |
-        uv pip install tessera --system
+        uv pip install tessera-contracts[cli] --system
 
     - name: Run dbt check
       id: check


### PR DESCRIPTION
## Summary

- Fixes GitHub Action package reference (#133) - updated from `tessera` to `tessera-contracts[cli]`
- Implements Phase 2 of SLA/Guarantees epic (#148) - adds guarantee support to OpenAPI and GraphQL integrations

## Changes

### OpenAPI Guarantees
- Added `guarantees` field to `OpenAPIEndpoint` and `AssetFromOpenAPI` models
- Implemented `_extract_tessera_guarantees()` to parse `x-tessera` OpenAPI extensions
- Implemented `_infer_nullability_from_schema()` to detect required fields from JSON Schema
- Implemented `_merge_guarantees()` helper for combining guarantee sources
- Guarantees are merged in priority order: inferred nullability → explicit x-tessera

### GraphQL Guarantees
- Added `guarantees` field to `GraphQLOperation` and `AssetFromGraphQL` models
- NON_NULL arguments are automatically inferred as nullability guarantees

### Import API
- Added `default_guarantees` field to OpenAPI/GraphQL import request models
- Contracts created during import now include merged guarantees from:
  1. `default_guarantees` (lowest priority)
  2. Per-operation guarantees (from x-tessera or inferred)

### Tests
- Added 19 new tests for guarantee extraction and merging

## Test plan
- [x] All 673 tests pass locally
- [x] New guarantee tests cover all edge cases
- [ ] CI pipeline passes

Closes #133
Partially addresses #148