### PR TITLE
Add downstream assets section to asset detail UI

### DIFF
--- a/src/tessera/static/js/api.js
+++ b/src/tessera/static/js/api.js
@@ -264,6 +264,10 @@ class TesseraAPI {
     return this.request(`/assets/${assetId}/dependencies`);
   }
 
+  async getAssetLineage(assetId, depth = 1) {
+    return this.request(`/assets/${assetId}/lineage?depth=${depth}`);
+  }
+
   async createDependency(assetId, data) {
     return this.request(`/assets/${assetId}/dependencies`, {
       method: 'POST',

--- a/src/tessera/templates/asset_detail.html
+++ b/src/tessera/templates/asset_detail.html
@@ -58,6 +58,13 @@
   </div>
 </section>
 
+<section>
+  <h2>Dependents (Downstream)</h2>
+  <div id="asset-dependents">
+    <div class="loading">Loading...</div>
+  </div>
+</section>
+
 <!-- Modal Dialogs -->
 <div id="modal-overlay" class="modal-overlay" style="display: none;" onclick="closeModal()"></div>
 
@@ -961,6 +968,41 @@ async function loadAssetDetail() {
       }
     } catch (e) {
       depsContainer.innerHTML = '<div class="empty">No dependencies.</div>';
+    }
+
+    // Downstream dependents (assets that depend on this one)
+    const dependentsContainer = document.getElementById('asset-dependents');
+    try {
+      const lineageData = await api.getAssetLineage(assetId);
+      const downstreamAssets = lineageData.downstream_assets || [];
+
+      if (downstreamAssets.length === 0) {
+        dependentsContainer.innerHTML = '<div class="empty">No downstream dependents. No models reference this asset.</div>';
+      } else {
+        dependentsContainer.innerHTML = `
+          <p style="margin-bottom: 0.5rem;"><strong>${downstreamAssets.length}</strong> model(s) depend on this asset:</p>
+          <table>
+            <thead>
+              <tr>
+                <th>Dependent Asset</th>
+                <th>Type</th>
+                <th>Owner Team</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${downstreamAssets.map(d => `
+                <tr>
+                  <td><a href="/assets/${d.id}">${escapeHtml(d.fqn || d.id)}</a></td>
+                  <td>${escapeHtml(d.dependency_type || 'ref')}</td>
+                  <td><a href="/teams/${d.owner_team_id}">${escapeHtml(d.owner_team_name || d.owner_team_id)}</a></td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        `;
+      }
+    } catch (e) {
+      dependentsContainer.innerHTML = '<div class="empty">No downstream dependents.</div>';
     }
   } catch (error) {
     showError(error.message);


### PR DESCRIPTION
## Summary
- Added a "Dependents (Downstream)" section to the asset detail page that shows which models depend on/reference the current asset
- Added `getAssetLineage` method to the JavaScript API client to fetch lineage data
- Uses the existing `/assets/{id}/lineage` endpoint which already returns `downstream_assets`

## Test plan
- [ ] Navigate to an asset that is referenced by other models (e.g., a staging model)
- [ ] Verify the "Dependents (Downstream)" section shows the correct downstream assets
- [ ] Verify each dependent links to its detail page
- [ ] Verify empty state shows correctly for assets with no dependents