### PR TITLE
Improve search performance

### DIFF
--- a/alembic/versions/006_add_search_trgm_indexes.py
+++ b/alembic/versions/006_add_search_trgm_indexes.py
@@ -1,0 +1,69 @@
+"""Add trigram indexes for search performance.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2025-12-29
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Create trigram indexes for ILIKE search."""
+    if _is_sqlite():
+        return
+
+    schema = "core"
+    schema_prefix = f"{schema}."
+
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS ix_teams_name_trgm "
+        f"ON {schema_prefix}teams USING gin (name gin_trgm_ops)"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS ix_users_name_trgm "
+        f"ON {schema_prefix}users USING gin (name gin_trgm_ops)"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS ix_users_email_trgm "
+        f"ON {schema_prefix}users USING gin (email gin_trgm_ops)"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS ix_assets_fqn_trgm "
+        f"ON {schema_prefix}assets USING gin (fqn gin_trgm_ops)"
+    )
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS ix_contracts_version_trgm "
+        f"ON {schema_prefix}contracts USING gin (version gin_trgm_ops)"
+    )
+
+
+def downgrade() -> None:
+    """Drop trigram indexes."""
+    if _is_sqlite():
+        return
+
+    schema = "core"
+    schema_prefix = f"{schema}."
+
+    op.execute(f"DROP INDEX IF EXISTS {schema_prefix}ix_contracts_version_trgm")
+    op.execute(f"DROP INDEX IF EXISTS {schema_prefix}ix_assets_fqn_trgm")
+    op.execute(f"DROP INDEX IF EXISTS {schema_prefix}ix_users_email_trgm")
+    op.execute(f"DROP INDEX IF EXISTS {schema_prefix}ix_users_name_trgm")
+    op.execute(f"DROP INDEX IF EXISTS {schema_prefix}ix_teams_name_trgm")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,12 +12,14 @@ from tessera.services.cache import (
     cache_asset_contracts_list,
     cache_asset_search,
     cache_contract,
+    cache_global_search,
     cache_schema_diff,
     close_redis,
     get_cached_asset,
     get_cached_asset_contracts_list,
     get_cached_asset_search,
     get_cached_contract,
+    get_cached_global_search,
     get_cached_schema_diff,
     get_redis_client,
     invalidate_asset,
@@ -161,6 +163,16 @@ class TestCacheConvenienceFunctions:
     async def test_get_cached_asset_search_without_redis(self):
         """Get cached asset search returns None without Redis."""
         result = await get_cached_asset_search("query", {"status": "active"})
+        assert result is None
+
+    async def test_cache_global_search_without_redis(self):
+        """Cache global search gracefully handles no Redis."""
+        result = await cache_global_search("query", 10, {"results": {}})
+        assert result is False
+
+    async def test_get_cached_global_search_without_redis(self):
+        """Get cached global search returns None without Redis."""
+        result = await get_cached_global_search("query", 10)
         assert result is None
 
 


### PR DESCRIPTION
## Summary
- add Postgres trigram indexes for search-heavy fields (teams, users, assets, contracts)
- cache global search results for default limit to reduce repeated queries
- increase API key prefix length with backward-compatible validation
- add tests for global search caching and legacy prefix validation

## Testing
- DATABASE_URL=sqlite+aiosqlite:///:memory: uv run pytest tests/test_auth.py tests/test_cache.py tests/test_search.py -v
