### PR TITLE
Expand API key prefix storage

### DIFF
--- a/alembic/versions/006_expand_api_key_prefix_length.py
+++ b/alembic/versions/006_expand_api_key_prefix_length.py
@@ -1,0 +1,53 @@
+"""Expand api_keys.key_prefix length.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2025-01-03
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Expand key_prefix to fit longer prefixes."""
+    if _is_sqlite():
+        return
+
+    op.alter_column(
+        "api_keys",
+        "key_prefix",
+        existing_type=sa.String(length=20),
+        type_=sa.String(length=32),
+        schema="core",
+    )
+
+
+def downgrade() -> None:
+    """Revert key_prefix length to previous size."""
+    if _is_sqlite():
+        return
+
+    op.alter_column(
+        "api_keys",
+        "key_prefix",
+        existing_type=sa.String(length=32),
+        type_=sa.String(length=20),
+        schema="core",
+    )

--- a/src/tessera/db/models.py
+++ b/src/tessera/db/models.py
@@ -294,7 +294,7 @@ class APIKeyDB(Base):
         String(128), nullable=False, unique=True
     )  # argon2 hashes are ~100 chars
     key_prefix: Mapped[str] = mapped_column(
-        String(20), nullable=False, index=True
+        String(32), nullable=False, index=True
     )  # indexed for prefix-based lookup
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     team_id: Mapped[UUID] = mapped_column(Uuid, ForeignKey("teams.id"), nullable=False, index=True)


### PR DESCRIPTION
## Summary
- expand API key prefix column to 32 chars
- add migration to alter api_keys.key_prefix length

## Testing
- ruff
- ruff format
- mypy