### PR TITLE
Fix security review issues: session secret, cache invalidation, DNS timeout

### DIFF
--- a/src/tessera/services/cache.py
+++ b/src/tessera/services/cache.py
@@ -259,7 +259,9 @@ async def invalidate_asset(asset_id: str) -> bool:
     # Invalidate individual contract caches
     contracts_deleted = await invalidate_asset_contracts(asset_id)
     # Invalidate all search caches (search results may include this asset)
+    # Asset-specific searches are in asset_cache, global searches are in search_cache
     await asset_cache.invalidate_pattern("search:*")
+    await search_cache.invalidate_pattern("global:*")
     return asset_deleted or contracts_list_deleted or contracts_deleted > 0
 
 


### PR DESCRIPTION
## Summary

- **High**: Fail fast in production if `SESSION_SECRET_KEY` uses default value (prevents session forgery attacks)
- **Medium**: Fix global search cache invalidation to also clear `search_cache` (was only clearing `asset_cache`, causing stale search results)
- **Low**: Add 5-second timeout to webhook DNS resolution (prevents slow DNS from blocking webhook delivery)

## Changes

### `src/tessera/config.py`
- Added `model_validator` that raises `ValueError` if `environment == "production"` and `session_secret_key` is the default

### `src/tessera/services/cache.py`
- `invalidate_asset()` now also calls `search_cache.invalidate_pattern("global:*")` to clear global search results

### `src/tessera/services/webhooks.py`
- Wrapped `loop.getaddrinfo()` in `asyncio.wait_for(timeout=5.0)` to prevent slow DNS from stalling webhook delivery
- Added `TimeoutError` exception handling that returns validation failure

## Test plan
- [x] All 791 tests pass
- [x] Pre-commit hooks pass (ruff, mypy, formatting)
- [ ] Verify CI passes