### PR TITLE
Add tiered acknowledgment model with affected parties and objections

### DIFF
--- a/src/tessera/db/models.py
+++ b/src/tessera/db/models.py
@@ -29,6 +29,7 @@ from tessera.models.enums import (
     RegistrationStatus,
     ResourceType,
     SchemaFormat,
+    SemverMode,
     UserRole,
     WebhookDeliveryStatus,
 )
@@ -110,6 +111,7 @@ class AssetDB(Base):
     guarantee_mode: Mapped[GuaranteeMode] = mapped_column(
         Enum(GuaranteeMode), default=GuaranteeMode.NOTIFY
     )
+    semver_mode: Mapped[SemverMode] = mapped_column(Enum(SemverMode), default=SemverMode.AUTO)
     metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSON, default=dict)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     deleted_at: Mapped[datetime | None] = mapped_column(
@@ -216,6 +218,14 @@ class ProposalDB(Base):
         DateTime(timezone=True), nullable=True, index=True
     )
     auto_expire: Mapped[bool] = mapped_column(default=False)
+
+    # Affected parties discovered via lineage (not registered consumers)
+    # Teams owning downstream assets that will be affected by this change
+    affected_teams: Mapped[list[dict[str, Any]]] = mapped_column(JSON, default=list)
+    # Downstream assets that depend on this asset and will be affected
+    affected_assets: Mapped[list[dict[str, Any]]] = mapped_column(JSON, default=list)
+    # Objections filed by affected teams (non-blocking but visible)
+    objections: Mapped[list[dict[str, Any]]] = mapped_column(JSON, default=list)
 
     # Relationships
     asset: Mapped["AssetDB"] = relationship(back_populates="proposals")

--- a/src/tessera/models/__init__.py
+++ b/src/tessera/models/__init__.py
@@ -37,7 +37,14 @@ from tessera.models.enums import (
     ProposalStatus,
     RegistrationStatus,
 )
-from tessera.models.proposal import Proposal, ProposalCreate
+from tessera.models.proposal import (
+    AffectedAsset,
+    AffectedTeam,
+    Objection,
+    ObjectionCreate,
+    Proposal,
+    ProposalCreate,
+)
 from tessera.models.registration import Registration, RegistrationCreate, RegistrationUpdate
 from tessera.models.team import Team, TeamCreate, TeamUpdate
 from tessera.models.user import User, UserCreate, UserUpdate, UserWithTeam
@@ -79,6 +86,10 @@ __all__ = [
     "RegistrationCreate",
     "RegistrationUpdate",
     # Proposal
+    "AffectedAsset",
+    "AffectedTeam",
+    "Objection",
+    "ObjectionCreate",
     "Proposal",
     "ProposalCreate",
     # Acknowledgment

--- a/src/tessera/models/asset.py
+++ b/src/tessera/models/asset.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from tessera.config import settings
-from tessera.models.enums import GuaranteeMode, ResourceType
+from tessera.models.enums import GuaranteeMode, ResourceType, SemverMode
 
 # FQN pattern: alphanumeric/underscores separated by dots, at least 2 segments
 # Examples: db.schema.table, schema.table, my_db.my_schema.my_table
@@ -52,6 +52,7 @@ class AssetCreate(AssetBase):
     owner_user_id: UUID | None = None
     resource_type: ResourceType = ResourceType.OTHER
     guarantee_mode: GuaranteeMode = GuaranteeMode.NOTIFY
+    semver_mode: SemverMode = SemverMode.AUTO
 
 
 class AssetUpdate(BaseModel):
@@ -63,6 +64,7 @@ class AssetUpdate(BaseModel):
     environment: str | None = Field(None, min_length=1, max_length=50)
     resource_type: ResourceType | None = None
     guarantee_mode: GuaranteeMode | None = None
+    semver_mode: SemverMode | None = None
     metadata: dict[str, Any] | None = None
 
 
@@ -78,6 +80,7 @@ class Asset(BaseModel):
     environment: str
     resource_type: ResourceType = ResourceType.OTHER
     guarantee_mode: GuaranteeMode = GuaranteeMode.NOTIFY
+    semver_mode: SemverMode = SemverMode.AUTO
     metadata: dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_")
     created_at: datetime
 

--- a/src/tessera/models/contract.py
+++ b/src/tessera/models/contract.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from tessera.config import settings
-from tessera.models.enums import CompatibilityMode, ContractStatus, SchemaFormat
+from tessera.models.enums import ChangeType, CompatibilityMode, ContractStatus, SchemaFormat
 
 
 class Guarantees(BaseModel):
@@ -97,3 +97,27 @@ class Contract(ContractBase):
     published_at: datetime
     published_by: UUID
     published_by_user_id: UUID | None = None
+
+
+class VersionSuggestion(BaseModel):
+    """Suggested version based on schema diff analysis.
+
+    Returned when asset.semver_mode is 'suggest' and no version is provided,
+    or included in validation errors when semver_mode is 'enforce'.
+    """
+
+    suggested_version: str = Field(
+        ..., description="The suggested semantic version based on schema changes"
+    )
+    current_version: str | None = Field(
+        None, description="The current contract version (None for first contract)"
+    )
+    change_type: ChangeType = Field(
+        ..., description="The detected change type (major, minor, patch)"
+    )
+    reason: str = Field(
+        ..., description="Human-readable explanation of why this version was suggested"
+    )
+    is_first_contract: bool = Field(
+        False, description="True if this is the first contract for the asset"
+    )

--- a/src/tessera/models/enums.py
+++ b/src/tessera/models/enums.py
@@ -86,6 +86,17 @@ class GuaranteeMode(StrEnum):
     IGNORE = "ignore"  # Don't track guarantee changes
 
 
+class SemverMode(StrEnum):
+    """Semantic versioning enforcement mode for assets.
+
+    Controls how version numbers are handled when publishing contracts.
+    """
+
+    AUTO = "auto"  # Automatically assign version based on change type (default)
+    SUGGEST = "suggest"  # Return suggested version; user can override
+    ENFORCE = "enforce"  # Reject if user-provided version doesn't match change type
+
+
 class GuaranteeChangeSeverity(StrEnum):
     """Severity of a guarantee change."""
 

--- a/src/tessera/models/proposal.py
+++ b/src/tessera/models/proposal.py
@@ -17,6 +17,51 @@ class BreakingChange(BaseModel):
     details: dict[str, Any] = Field(default_factory=dict)
 
 
+class AffectedAsset(BaseModel):
+    """An asset affected by a proposal via lineage."""
+
+    asset_id: str = Field(..., description="ID of the affected downstream asset")
+    asset_fqn: str = Field(..., description="FQN of the affected downstream asset")
+    owner_team_id: str = Field(..., description="Team ID that owns this asset")
+    owner_team_name: str | None = Field(None, description="Team name that owns this asset")
+    owner_user_id: str | None = Field(None, description="Individual user ID that owns this asset")
+    owner_user_name: str | None = Field(
+        None, description="Individual user name that owns this asset"
+    )
+
+
+class AffectedTeam(BaseModel):
+    """A team affected by a proposal via lineage (owning downstream assets)."""
+
+    team_id: str = Field(..., description="ID of the affected team")
+    team_name: str = Field(..., description="Name of the affected team")
+    assets: list[str] = Field(
+        default_factory=list, description="Asset IDs owned by this team that are affected"
+    )
+
+
+class Objection(BaseModel):
+    """An objection filed by an affected team."""
+
+    team_id: str = Field(..., description="ID of the team that objected")
+    team_name: str = Field(..., description="Name of the team that objected")
+    reason: str = Field(..., description="Reason for the objection")
+    objected_at: datetime = Field(..., description="When the objection was filed")
+    objected_by_user_id: str | None = Field(None, description="User ID who filed the objection")
+    objected_by_user_name: str | None = Field(None, description="User name who filed the objection")
+
+
+class ObjectionCreate(BaseModel):
+    """Request body for filing an objection to a proposal."""
+
+    reason: str = Field(
+        ...,
+        min_length=1,
+        max_length=1000,
+        description="Reason for objecting to this proposal",
+    )
+
+
 class ProposalBase(BaseModel):
     """Base proposal fields."""
 
@@ -45,3 +90,25 @@ class Proposal(ProposalBase):
     resolved_at: datetime | None = None
     expires_at: datetime | None = None
     auto_expire: bool = False
+
+    # Affected parties discovered via lineage (not registered consumers)
+    affected_teams: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Teams owning downstream assets affected by this change",
+    )
+    affected_assets: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Downstream assets that depend on this asset",
+    )
+    objections: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Objections filed by affected teams (non-blocking)",
+    )
+    has_objections: bool = Field(
+        default=False,
+        description="True if any affected teams have objected",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        """Compute has_objections from objections list."""
+        object.__setattr__(self, "has_objections", len(self.objections) > 0)

--- a/src/tessera/services/__init__.py
+++ b/src/tessera/services/__init__.py
@@ -1,5 +1,6 @@
 """Business logic services."""
 
+from tessera.services.affected_parties import get_affected_parties
 from tessera.services.audit import (
     AuditAction,
     log_contract_published,
@@ -44,6 +45,8 @@ from tessera.services.schema_validator import (
 )
 
 __all__ = [
+    # Affected parties
+    "get_affected_parties",
     # Schema diffing
     "BreakingChange",
     "SchemaDiff",

--- a/src/tessera/services/affected_parties.py
+++ b/src/tessera/services/affected_parties.py
@@ -1,0 +1,157 @@
+"""Service for computing affected parties from lineage.
+
+This module provides functions to discover teams and assets that will be affected
+by changes to an asset, based on dependency relationships (both explicit and
+via metadata.depends_on).
+"""
+
+from collections import defaultdict
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tessera.db import AssetDB, AssetDependencyDB, TeamDB, UserDB
+
+
+async def get_affected_parties(
+    session: AsyncSession,
+    asset_id: UUID,
+    exclude_team_id: UUID | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Get teams and assets affected by changes to this asset via lineage.
+
+    Discovers downstream dependencies from:
+    1. The dependencies table (explicit asset-to-asset relationships)
+    2. The metadata.depends_on field (implicit relationships from dbt sync)
+
+    Args:
+        session: Database session
+        asset_id: The asset being changed
+        exclude_team_id: Optional team ID to exclude (typically the asset owner)
+
+    Returns:
+        A tuple of (affected_teams, affected_assets):
+        - affected_teams: List of dicts with team_id, team_name, assets
+        - affected_assets: List of dicts with asset details
+    """
+    # Get the asset being changed
+    asset_result = await session.execute(select(AssetDB).where(AssetDB.id == asset_id))
+    asset = asset_result.scalar_one_or_none()
+    if not asset:
+        return [], []
+
+    # Track affected assets and which teams own them
+    affected_assets: list[dict[str, Any]] = []
+    team_assets: dict[str, list[str]] = defaultdict(list)  # team_id -> [asset_ids]
+    seen_asset_ids: set[str] = set()
+
+    # 1. Query dependencies table for assets that depend on this asset
+    dep_asset = AssetDB.__table__.alias("dep_asset")
+    dep_team = TeamDB.__table__.alias("dep_team")
+
+    downstream_result = await session.execute(
+        select(
+            AssetDependencyDB.dependent_asset_id,
+            dep_asset.c.fqn,
+            dep_asset.c.owner_team_id,
+            dep_asset.c.owner_user_id,
+            dep_team.c.name.label("team_name"),
+        )
+        .join(dep_asset, AssetDependencyDB.dependent_asset_id == dep_asset.c.id)
+        .join(dep_team, dep_asset.c.owner_team_id == dep_team.c.id)
+        .where(AssetDependencyDB.dependency_asset_id == asset_id)
+        .where(dep_asset.c.deleted_at.is_(None))
+    )
+
+    for row in downstream_result.all():
+        dep_asset_id, fqn, owner_team_id, owner_user_id, team_name = row
+        asset_id_str = str(dep_asset_id)
+        team_id_str = str(owner_team_id)
+
+        # Skip if excluding this team
+        if exclude_team_id and owner_team_id == exclude_team_id:
+            continue
+
+        if asset_id_str not in seen_asset_ids:
+            seen_asset_ids.add(asset_id_str)
+            affected_assets.append(
+                {
+                    "asset_id": asset_id_str,
+                    "asset_fqn": fqn,
+                    "owner_team_id": team_id_str,
+                    "owner_team_name": team_name,
+                    "owner_user_id": str(owner_user_id) if owner_user_id else None,
+                }
+            )
+            team_assets[team_id_str].append(asset_id_str)
+
+    # 2. Check metadata.depends_on for assets not in dependencies table
+    # Find all assets whose metadata.depends_on contains this asset's FQN
+    all_assets_result = await session.execute(
+        select(AssetDB, TeamDB)
+        .join(TeamDB, AssetDB.owner_team_id == TeamDB.id)
+        .where(AssetDB.deleted_at.is_(None))
+        .where(AssetDB.id != asset_id)  # Exclude the asset being changed
+    )
+
+    for downstream_asset, downstream_team in all_assets_result.all():
+        # Skip if excluding this team
+        if exclude_team_id and downstream_asset.owner_team_id == exclude_team_id:
+            continue
+
+        depends_on = downstream_asset.metadata_.get("depends_on", [])
+        if asset.fqn in depends_on:
+            asset_id_str = str(downstream_asset.id)
+            team_id_str = str(downstream_asset.owner_team_id)
+
+            if asset_id_str not in seen_asset_ids:
+                seen_asset_ids.add(asset_id_str)
+                affected_assets.append(
+                    {
+                        "asset_id": asset_id_str,
+                        "asset_fqn": downstream_asset.fqn,
+                        "owner_team_id": team_id_str,
+                        "owner_team_name": downstream_team.name,
+                        "owner_user_id": str(downstream_asset.owner_user_id)
+                        if downstream_asset.owner_user_id
+                        else None,
+                    }
+                )
+                team_assets[team_id_str].append(asset_id_str)
+
+    # 3. Fetch user names for assets with owner_user_id
+    user_ids_to_lookup = {
+        UUID(a["owner_user_id"]) for a in affected_assets if a.get("owner_user_id")
+    }
+    users_map: dict[UUID, str] = {}
+    if user_ids_to_lookup:
+        users_result = await session.execute(
+            select(UserDB.id, UserDB.name).where(UserDB.id.in_(user_ids_to_lookup))
+        )
+        users_map = {uid: name for uid, name in users_result.all()}
+
+    # Add user names to affected assets
+    for asset_dict in affected_assets:
+        if asset_dict.get("owner_user_id"):
+            user_id = UUID(asset_dict["owner_user_id"])
+            asset_dict["owner_user_name"] = users_map.get(user_id)
+
+    # 4. Build affected teams list from aggregated data
+    affected_teams: list[dict[str, Any]] = []
+    for team_id_str, asset_ids in team_assets.items():
+        # Get team name from any asset in this team's list
+        team_name = next(
+            (a["owner_team_name"] for a in affected_assets if a["owner_team_id"] == team_id_str),
+            "Unknown",
+        )
+        affected_teams.append(
+            {
+                "team_id": team_id_str,
+                "team_name": team_name,
+                "assets": asset_ids,
+            }
+        )
+
+    return affected_teams, affected_assets

--- a/src/tessera/templates/asset_detail.html
+++ b/src/tessera/templates/asset_detail.html
@@ -992,9 +992,9 @@ async function loadAssetDetail() {
             <tbody>
               ${downstreamAssets.map(d => `
                 <tr>
-                  <td><a href="/assets/${d.id}">${escapeHtml(d.fqn || d.id)}</a></td>
-                  <td>${escapeHtml(d.dependency_type || 'ref')}</td>
-                  <td><a href="/teams/${d.owner_team_id}">${escapeHtml(d.owner_team_name || d.owner_team_id)}</a></td>
+                  <td><a href="/assets/${d.asset_id}">${escapeHtml(d.asset_fqn || d.asset_id)}</a></td>
+                  <td>${escapeHtml(d.dependency_type || 'consumes')}</td>
+                  <td>${escapeHtml(d.owner_team || 'Unknown')}</td>
                 </tr>
               `).join('')}
             </tbody>

--- a/src/tessera/templates/proposal_detail.html
+++ b/src/tessera/templates/proposal_detail.html
@@ -31,6 +31,20 @@
 </section>
 
 <section>
+  <h2>Affected Downstream Teams (via Lineage)</h2>
+  <div id="affected-parties">
+    <div class="loading">Loading...</div>
+  </div>
+</section>
+
+<section>
+  <h2>Objections</h2>
+  <div id="objections">
+    <div class="loading">Loading...</div>
+  </div>
+</section>
+
+<section>
   <h2>Acknowledgments</h2>
   <div id="acknowledgments">
     <div class="loading">Loading...</div>
@@ -509,6 +523,97 @@ async function loadProposalDetail() {
           ` : ''}
         </div>
       `;
+    }
+
+    // Affected Parties (lineage-discovered teams)
+    const affectedContainer = document.getElementById('affected-parties');
+    const affectedTeams = proposal.affected_teams || [];
+    const affectedAssets = proposal.affected_assets || [];
+
+    if (affectedTeams.length > 0 || affectedAssets.length > 0) {
+      affectedContainer.innerHTML = `
+        <div class="card" style="border-left: 6px solid #5555ff; background: #f5f5ff;">
+          <p style="margin-top: 0;">
+            <strong>${affectedTeams.length}</strong> team${affectedTeams.length !== 1 ? 's' : ''} own
+            <strong>${affectedAssets.length}</strong> downstream asset${affectedAssets.length !== 1 ? 's' : ''}
+            that depend on this asset and may be affected by this change.
+          </p>
+          <p style="color: var(--gray); font-size: 0.9rem;">
+            These teams will be notified and can file objections, but their approval is not required.
+          </p>
+
+          ${affectedAssets.length > 0 ? `
+            <h4 style="margin: 1rem 0 0.5rem 0;">Affected Downstream Assets</h4>
+            <table>
+              <thead>
+                <tr>
+                  <th>Asset</th>
+                  <th>Owner Team</th>
+                  <th>Owner User</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${affectedAssets.map(a => `
+                  <tr>
+                    <td><a href="/assets/${a.asset_id}"><code>${escapeHtml(a.asset_fqn)}</code></a></td>
+                    <td><a href="/teams/${a.owner_team_id}">${escapeHtml(a.owner_team_name || 'Unknown')}</a></td>
+                    <td>${a.owner_user_name
+                      ? `<a href="/users/${a.owner_user_id}">${escapeHtml(a.owner_user_name)}</a>`
+                      : '<em style="color: var(--gray);">-</em>'
+                    }</td>
+                  </tr>
+                `).join('')}
+              </tbody>
+            </table>
+          ` : ''}
+        </div>
+      `;
+    } else {
+      affectedContainer.innerHTML = '<div class="empty">No downstream assets depend on this asset via lineage.</div>';
+    }
+
+    // Objections (non-blocking but prominently displayed)
+    const objectionsContainer = document.getElementById('objections');
+    const objections = proposal.objections || [];
+
+    if (objections.length > 0) {
+      objectionsContainer.innerHTML = `
+        <div class="card" style="border-left: 6px solid #ff8c00; background: #fff8f0;">
+          <div style="margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem;">
+            <span style="font-size: 1.25rem; color: #ff8c00;">!</span>
+            <strong style="color: #ff8c00;">${objections.length} Objection${objections.length !== 1 ? 's' : ''} Filed</strong>
+          </div>
+          <p style="color: var(--gray); font-size: 0.9rem; margin-top: 0;">
+            Objections are non-blocking. The proposal can still be approved, but these concerns
+            should be addressed through team coordination.
+          </p>
+          <table>
+            <thead>
+              <tr>
+                <th>Team</th>
+                <th>Filed By</th>
+                <th>Reason</th>
+                <th>Filed At</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${objections.map(o => `
+                <tr>
+                  <td><a href="/teams/${o.team_id}">${escapeHtml(o.team_name)}</a></td>
+                  <td>${o.objected_by_user_name
+                    ? `<a href="/users/${o.objected_by_user_id}">${escapeHtml(o.objected_by_user_name)}</a>`
+                    : '<em style="color: var(--gray);">-</em>'
+                  }</td>
+                  <td>${escapeHtml(o.reason)}</td>
+                  <td>${formatDate(o.objected_at)}</td>
+                </tr>
+              `).join('')}
+            </tbody>
+          </table>
+        </div>
+      `;
+    } else {
+      objectionsContainer.innerHTML = '<div class="empty">No objections have been filed.</div>';
     }
 
     // Acknowledgments

--- a/tests/test_affected_parties.py
+++ b/tests/test_affected_parties.py
@@ -1,0 +1,411 @@
+"""Tests for affected parties and objections functionality."""
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestAffectedParties:
+    """Test that proposals compute and store affected parties."""
+
+    @pytest.mark.asyncio
+    async def test_proposal_includes_affected_parties_from_dependencies_table(
+        self, client: AsyncClient
+    ) -> None:
+        """Test that affected parties are populated from dependencies table."""
+        # Create teams
+        owner_team = (await client.post("/api/v1/teams", json={"name": "owner-team"})).json()
+        downstream_team = (
+            await client.post("/api/v1/teams", json={"name": "downstream-team"})
+        ).json()
+
+        # Create upstream asset with contract
+        upstream = (
+            await client.post(
+                "/api/v1/assets", json={"fqn": "db.raw.orders", "owner_team_id": owner_team["id"]}
+            )
+        ).json()
+
+        schema_v1 = {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}},
+            "required": ["id"],
+        }
+        await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v1, "compatibility_mode": "backward"},
+        )
+
+        # Create downstream asset owned by different team
+        downstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.staging.stg_orders", "owner_team_id": downstream_team["id"]},
+            )
+        ).json()
+
+        # Create dependency: downstream depends on upstream
+        await client.post(
+            f"/api/v1/assets/{downstream['id']}/dependencies",
+            json={"depends_on_asset_id": upstream["id"]},
+        )
+
+        # Now publish a breaking change to upstream
+        schema_v2 = {
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        }  # type changed
+        result = await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v2, "compatibility_mode": "backward"},
+        )
+        assert result.status_code == 201
+        data = result.json()
+        assert data.get("action") == "proposal_created", f"Expected proposal, got: {data}"
+        proposal_id = data["proposal"]["id"]
+
+        # Fetch the proposal and verify affected parties
+        proposal = (await client.get(f"/api/v1/proposals/{proposal_id}")).json()
+
+        assert len(proposal["affected_teams"]) == 1
+        assert proposal["affected_teams"][0]["team_id"] == downstream_team["id"]
+        assert proposal["affected_teams"][0]["team_name"] == "downstream-team"
+
+        assert len(proposal["affected_assets"]) == 1
+        assert proposal["affected_assets"][0]["asset_fqn"] == "db.staging.stg_orders"
+        assert proposal["affected_assets"][0]["owner_team_id"] == downstream_team["id"]
+
+    @pytest.mark.asyncio
+    async def test_proposal_excludes_owner_team_from_affected_parties(
+        self, client: AsyncClient
+    ) -> None:
+        """Test that the asset owner's team is not included in affected parties."""
+        # Create team that owns both assets
+        owner_team = (await client.post("/api/v1/teams", json={"name": "same-owner"})).json()
+
+        # Create upstream asset with contract
+        upstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.raw.self_orders", "owner_team_id": owner_team["id"]},
+            )
+        ).json()
+
+        schema_v1 = {"type": "object", "properties": {"id": {"type": "integer"}}}
+        await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v1, "compatibility_mode": "backward"},
+        )
+
+        # Create downstream asset owned by SAME team
+        downstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.staging.self_stg", "owner_team_id": owner_team["id"]},
+            )
+        ).json()
+
+        # Create dependency
+        await client.post(
+            f"/api/v1/assets/{downstream['id']}/dependencies",
+            json={"depends_on_asset_id": upstream["id"]},
+        )
+
+        # Publish breaking change
+        schema_v2 = {"type": "object", "properties": {"id": {"type": "string"}}}
+        result = await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v2, "compatibility_mode": "backward"},
+        )
+        assert result.status_code == 201
+        data = result.json()
+        assert data.get("action") == "proposal_created"
+        proposal_id = data["proposal"]["id"]
+
+        proposal = (await client.get(f"/api/v1/proposals/{proposal_id}")).json()
+        # Same team should be excluded
+        assert len(proposal["affected_teams"]) == 0
+        assert len(proposal["affected_assets"]) == 0
+
+
+class TestObjections:
+    """Test objection filing and display."""
+
+    @pytest.mark.asyncio
+    async def test_affected_team_can_file_objection(self, client: AsyncClient) -> None:
+        """Test that an affected team can file an objection."""
+        # Setup: create teams and assets
+        owner_team = (await client.post("/api/v1/teams", json={"name": "obj-owner"})).json()
+        affected_team = (await client.post("/api/v1/teams", json={"name": "obj-affected"})).json()
+
+        upstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.raw.objection_test", "owner_team_id": owner_team["id"]},
+            )
+        ).json()
+
+        schema_v1 = {"type": "object", "properties": {"id": {"type": "integer"}}}
+        await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v1, "compatibility_mode": "backward"},
+        )
+
+        downstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.mart.objection_downstream", "owner_team_id": affected_team["id"]},
+            )
+        ).json()
+
+        await client.post(
+            f"/api/v1/assets/{downstream['id']}/dependencies",
+            json={"depends_on_asset_id": upstream["id"]},
+        )
+
+        # Create proposal via breaking change
+        schema_v2 = {"type": "object", "properties": {"id": {"type": "string"}}}
+        result = await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v2, "compatibility_mode": "backward"},
+        )
+        assert result.status_code == 201
+        proposal_id = result.json()["proposal"]["id"]
+
+        # File objection as affected team
+        objection_result = await client.post(
+            f"/api/v1/proposals/{proposal_id}/object",
+            params={"objector_team_id": affected_team["id"]},
+            json={"reason": "This will break our downstream pipeline!"},
+        )
+        assert objection_result.status_code == 201
+        obj_data = objection_result.json()
+        assert obj_data["action"] == "objection_filed"
+        assert obj_data["total_objections"] == 1
+        assert obj_data["objection"]["reason"] == "This will break our downstream pipeline!"
+
+        # Verify objection is stored in proposal
+        proposal = (await client.get(f"/api/v1/proposals/{proposal_id}")).json()
+        assert len(proposal["objections"]) == 1
+        assert proposal["objections"][0]["team_name"] == "obj-affected"
+        assert proposal["has_objections"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_affected_team_cannot_file_objection(self, client: AsyncClient) -> None:
+        """Test that a non-affected team cannot file an objection."""
+        owner_team = (await client.post("/api/v1/teams", json={"name": "obj-owner2"})).json()
+        random_team = (await client.post("/api/v1/teams", json={"name": "obj-random"})).json()
+
+        upstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.raw.no_objection_test", "owner_team_id": owner_team["id"]},
+            )
+        ).json()
+
+        schema_v1 = {"type": "object", "properties": {"id": {"type": "integer"}}}
+        await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v1, "compatibility_mode": "backward"},
+        )
+
+        # Create breaking change proposal (no dependencies, so no affected teams)
+        schema_v2 = {"type": "object", "properties": {"id": {"type": "string"}}}
+        result = await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v2, "compatibility_mode": "backward"},
+        )
+        assert result.status_code == 201
+        proposal_id = result.json()["proposal"]["id"]
+
+        # Random team tries to file objection
+        objection_result = await client.post(
+            f"/api/v1/proposals/{proposal_id}/object",
+            params={"objector_team_id": random_team["id"]},
+            json={"reason": "I want to object too!"},
+        )
+        assert (
+            objection_result.status_code == 403
+        ), f"Expected 403, got {objection_result.status_code}: {objection_result.json()}"
+        error_body = objection_result.json()
+        assert "Only affected teams" in error_body.get(
+            "message", error_body.get("error", {}).get("message", str(error_body))
+        )
+
+    @pytest.mark.asyncio
+    async def test_cannot_file_duplicate_objection(self, client: AsyncClient) -> None:
+        """Test that a team cannot file multiple objections to the same proposal."""
+        owner_team = (await client.post("/api/v1/teams", json={"name": "dup-owner"})).json()
+        affected_team = (await client.post("/api/v1/teams", json={"name": "dup-affected"})).json()
+
+        upstream = (
+            await client.post(
+                "/api/v1/assets", json={"fqn": "db.raw.dup_test", "owner_team_id": owner_team["id"]}
+            )
+        ).json()
+
+        schema_v1 = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v1, "compatibility_mode": "backward"},
+        )
+
+        downstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.mart.dup_downstream", "owner_team_id": affected_team["id"]},
+            )
+        ).json()
+
+        await client.post(
+            f"/api/v1/assets/{downstream['id']}/dependencies",
+            json={"depends_on_asset_id": upstream["id"]},
+        )
+
+        schema_v2 = {"type": "object", "properties": {"x": {"type": "string"}}}
+        result = await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v2, "compatibility_mode": "backward"},
+        )
+        assert result.status_code == 201
+        proposal_id = result.json()["proposal"]["id"]
+
+        # First objection succeeds
+        r1 = await client.post(
+            f"/api/v1/proposals/{proposal_id}/object",
+            params={"objector_team_id": affected_team["id"]},
+            json={"reason": "First objection"},
+        )
+        assert r1.status_code == 201
+
+        # Second objection from same team fails
+        r2 = await client.post(
+            f"/api/v1/proposals/{proposal_id}/object",
+            params={"objector_team_id": affected_team["id"]},
+            json={"reason": "Second objection attempt"},
+        )
+        assert r2.status_code == 409  # Duplicate
+
+    @pytest.mark.asyncio
+    async def test_objection_does_not_block_proposal(self, client: AsyncClient) -> None:
+        """Test that objections are non-blocking - proposal can still be force approved."""
+        owner_team = (await client.post("/api/v1/teams", json={"name": "nonblock-owner"})).json()
+        affected_team = (
+            await client.post("/api/v1/teams", json={"name": "nonblock-affected"})
+        ).json()
+
+        upstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.raw.nonblock_test", "owner_team_id": owner_team["id"]},
+            )
+        ).json()
+
+        schema_v1 = {"type": "object", "properties": {"y": {"type": "integer"}}}
+        await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v1, "compatibility_mode": "backward"},
+        )
+
+        downstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.mart.nonblock_down", "owner_team_id": affected_team["id"]},
+            )
+        ).json()
+
+        await client.post(
+            f"/api/v1/assets/{downstream['id']}/dependencies",
+            json={"depends_on_asset_id": upstream["id"]},
+        )
+
+        schema_v2 = {"type": "object", "properties": {"y": {"type": "string"}}}
+        result = await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v2, "compatibility_mode": "backward"},
+        )
+        assert result.status_code == 201
+        proposal_id = result.json()["proposal"]["id"]
+
+        # File objection
+        await client.post(
+            f"/api/v1/proposals/{proposal_id}/object",
+            params={"objector_team_id": affected_team["id"]},
+            json={"reason": "I object!"},
+        )
+
+        # Force approve still works despite objection
+        force_result = await client.post(
+            f"/api/v1/proposals/{proposal_id}/force",
+            params={"actor_id": owner_team["id"]},
+        )
+        assert force_result.status_code == 200
+        assert force_result.json()["status"] == "approved"
+
+
+class TestGetAffectedPartiesService:
+    """Test the get_affected_parties service function directly."""
+
+    @pytest.mark.asyncio
+    async def test_affected_parties_from_metadata_depends_on(self, client: AsyncClient) -> None:
+        """Test that affected parties are discovered from metadata.depends_on field."""
+        owner_team = (await client.post("/api/v1/teams", json={"name": "meta-owner"})).json()
+        downstream_team = (
+            await client.post("/api/v1/teams", json={"name": "meta-affected"})
+        ).json()
+
+        # Create upstream asset
+        upstream = (
+            await client.post(
+                "/api/v1/assets",
+                json={"fqn": "db.source.meta_src", "owner_team_id": owner_team["id"]},
+            )
+        ).json()
+
+        schema_v1 = {"type": "object", "properties": {"z": {"type": "integer"}}}
+        await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v1, "compatibility_mode": "backward"},
+        )
+
+        # Create downstream asset with metadata.depends_on
+        await client.post(
+            "/api/v1/assets",
+            json={
+                "fqn": "db.model.meta_model",
+                "owner_team_id": downstream_team["id"],
+                "metadata": {"depends_on": ["db.source.meta_src"]},
+            },
+        )
+
+        # Publish breaking change
+        schema_v2 = {"type": "object", "properties": {"z": {"type": "string"}}}
+        result = await client.post(
+            f"/api/v1/assets/{upstream['id']}/contracts",
+            params={"published_by": owner_team["id"]},
+            json={"schema": schema_v2, "compatibility_mode": "backward"},
+        )
+        assert result.status_code == 201
+
+        data = result.json()
+        assert data.get("action") == "proposal_created"
+        proposal_id = data["proposal"]["id"]
+
+        proposal = (await client.get(f"/api/v1/proposals/{proposal_id}")).json()
+        # Should find the downstream asset via metadata.depends_on
+        assert len(proposal["affected_assets"]) >= 1
+        affected_fqns = [a["asset_fqn"] for a in proposal["affected_assets"]]
+        assert "db.model.meta_model" in affected_fqns

--- a/tests/test_semver.py
+++ b/tests/test_semver.py
@@ -1,0 +1,460 @@
+"""Tests for semantic versioning enforcement (Issue #19)."""
+
+from httpx import AsyncClient
+
+from tests.conftest import make_asset, make_schema, make_team
+
+
+class TestSemverModes:
+    """Test semantic versioning enforcement modes."""
+
+    async def test_create_asset_with_default_semver_mode(self, client: AsyncClient):
+        """Assets default to AUTO semver mode."""
+        # Create team
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        assert resp.status_code == 201
+        team_id = resp.json()["id"]
+
+        # Create asset (no explicit semver_mode)
+        resp = await client.post(
+            "/api/v1/assets",
+            json=make_asset("db.schema.table", team_id),
+        )
+        assert resp.status_code == 201
+        asset = resp.json()
+        assert asset["semver_mode"] == "auto"
+
+    async def test_create_asset_with_explicit_semver_mode(self, client: AsyncClient):
+        """Can create asset with explicit semver mode."""
+        # Create team
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        # Create asset with ENFORCE mode
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.enforce_table", team_id), "semver_mode": "enforce"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["semver_mode"] == "enforce"
+
+        # Create asset with SUGGEST mode
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.suggest_table", team_id), "semver_mode": "suggest"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["semver_mode"] == "suggest"
+
+    async def test_update_asset_semver_mode(self, client: AsyncClient):
+        """Can update asset's semver mode."""
+        # Create team and asset
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json=make_asset("db.schema.table", team_id),
+        )
+        asset_id = resp.json()["id"]
+
+        # Update semver_mode
+        resp = await client.patch(
+            f"/api/v1/assets/{asset_id}",
+            json={"semver_mode": "enforce"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["semver_mode"] == "enforce"
+
+
+class TestAutoSemverMode:
+    """Test AUTO semver mode (default behavior)."""
+
+    async def test_first_contract_auto_version(self, client: AsyncClient):
+        """First contract gets version 1.0.0 when not specified."""
+        # Setup
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json=make_asset("db.schema.table", team_id),
+        )
+        asset_id = resp.json()["id"]
+
+        # Publish first contract without version
+        schema = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["action"] == "published"
+        assert data["contract"]["version"] == "1.0.0"
+        assert data["version_auto_generated"] is True
+
+    async def test_minor_change_auto_bumps_version(self, client: AsyncClient):
+        """Adding fields auto-bumps minor version."""
+        # Setup
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json=make_asset("db.schema.table", team_id),
+        )
+        asset_id = resp.json()["id"]
+
+        # Publish first contract
+        schema_v1 = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v1, "version": "1.0.0"},
+        )
+        assert resp.status_code == 201
+
+        # Add optional field (minor change)
+        schema_v2 = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"},  # New optional field
+            },
+            "required": ["id", "name"],
+        }
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v2},  # No version - should auto-bump
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["contract"]["version"] == "1.1.0"
+        assert data["version_auto_generated"] is True
+
+
+class TestSuggestSemverMode:
+    """Test SUGGEST semver mode."""
+
+    async def test_suggest_mode_returns_suggestion(self, client: AsyncClient):
+        """SUGGEST mode returns version suggestion when no version provided."""
+        # Setup with SUGGEST mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "suggest"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract - should return version_required action
+        schema = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema},
+        )
+        # SUGGEST mode returns version_required action with suggestion
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "version_required"
+        assert "version_suggestion" in data
+        assert data["version_suggestion"]["suggested_version"] == "1.0.0"
+        assert data["version_suggestion"]["is_first_contract"] is True
+
+    async def test_suggest_mode_with_explicit_version(self, client: AsyncClient):
+        """SUGGEST mode accepts explicit version."""
+        # Setup with SUGGEST mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "suggest"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract with explicit version
+        schema = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema, "version": "1.0.0"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["contract"]["version"] == "1.0.0"
+
+    async def test_suggest_mode_suggests_minor_bump(self, client: AsyncClient):
+        """SUGGEST mode suggests minor bump for compatible additions."""
+        # Setup with SUGGEST mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "suggest"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract
+        schema_v1 = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v1, "version": "1.0.0"},
+        )
+        assert resp.status_code == 201
+
+        # Add optional field (minor change) without version
+        schema_v2 = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+            },
+            "required": ["id", "name"],
+        }
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v2},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "version_required"
+        assert data["version_suggestion"]["suggested_version"] == "1.1.0"
+        assert data["version_suggestion"]["change_type"] == "minor"
+
+
+class TestEnforceSemverMode:
+    """Test ENFORCE semver mode."""
+
+    async def test_enforce_mode_rejects_wrong_version(self, client: AsyncClient):
+        """ENFORCE mode rejects version that doesn't match change type."""
+        # Setup with ENFORCE mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "enforce"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract
+        schema_v1 = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v1, "version": "1.0.0"},
+        )
+        assert resp.status_code == 201
+
+        # Try to publish minor change with patch version (should fail)
+        schema_v2 = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+            },
+            "required": ["id", "name"],
+        }
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v2, "version": "1.0.1"},  # Wrong - should be 1.1.0
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["code"] == "INVALID_VERSION"
+        assert "version_suggestion" in data["details"]
+        assert data["details"]["version_suggestion"]["suggested_version"] == "1.1.0"
+
+    async def test_enforce_mode_accepts_correct_version(self, client: AsyncClient):
+        """ENFORCE mode accepts version that matches change type."""
+        # Setup with ENFORCE mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "enforce"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract
+        schema_v1 = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v1, "version": "1.0.0"},
+        )
+        assert resp.status_code == 201
+
+        # Publish minor change with correct version
+        schema_v2 = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+            },
+            "required": ["id", "name"],
+        }
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v2, "version": "1.1.0"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["contract"]["version"] == "1.1.0"
+
+    async def test_enforce_mode_allows_major_for_minor_change(self, client: AsyncClient):
+        """ENFORCE mode allows major bump for minor changes (more conservative)."""
+        # Setup with ENFORCE mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "enforce"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract
+        schema_v1 = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v1, "version": "1.0.0"},
+        )
+        assert resp.status_code == 201
+
+        # Publish minor change with major version (should be allowed)
+        schema_v2 = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+            },
+            "required": ["id", "name"],
+        }
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v2, "version": "2.0.0"},  # Major bump for minor change is OK
+        )
+        assert resp.status_code == 201
+        assert resp.json()["contract"]["version"] == "2.0.0"
+
+    async def test_enforce_mode_requires_major_for_breaking(self, client: AsyncClient):
+        """ENFORCE mode requires major bump for breaking changes."""
+        # Setup with ENFORCE mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "enforce"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract
+        schema_v1 = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v1, "version": "1.0.0"},
+        )
+        assert resp.status_code == 201
+
+        # Remove required field (breaking change)
+        schema_v2 = make_schema(id="integer")  # Removed 'name'
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id, "force": "true"},  # force to skip proposal
+            json={"schema": schema_v2, "version": "1.1.0"},  # Wrong - should be 2.0.0
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["code"] == "INVALID_VERSION"
+        assert "major version bump" in data["detail"].lower()
+
+
+class TestVersionValidation:
+    """Test version validation helper functions."""
+
+    async def test_version_must_be_greater(self, client: AsyncClient):
+        """Version must be greater than current version."""
+        # Setup with ENFORCE mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "enforce"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract
+        schema_v1 = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v1, "version": "2.0.0"},  # Start at 2.0.0
+        )
+        assert resp.status_code == 201
+
+        # Try to publish with lower version
+        schema_v2 = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"},
+            },
+            "required": ["id", "name"],
+        }
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema_v2, "version": "1.5.0"},  # Lower than 2.0.0
+        )
+        assert resp.status_code == 400
+        assert "must be greater than" in resp.json()["detail"].lower()
+
+
+class TestVersionSuggestionModel:
+    """Test the VersionSuggestion response model."""
+
+    async def test_version_suggestion_includes_reason(self, client: AsyncClient):
+        """Version suggestion includes human-readable reason."""
+        # Setup with SUGGEST mode
+        resp = await client.post("/api/v1/teams", json=make_team("test-team"))
+        team_id = resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/assets",
+            json={**make_asset("db.schema.table", team_id), "semver_mode": "suggest"},
+        )
+        asset_id = resp.json()["id"]
+
+        # First contract request
+        schema = make_schema(id="integer", name="string")
+        resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts",
+            params={"published_by": team_id},
+            json={"schema": schema},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "reason" in data["version_suggestion"]
+        assert len(data["version_suggestion"]["reason"]) > 0


### PR DESCRIPTION
- Add affected_teams, affected_assets, objections JSON columns to ProposalDB
- Create get_affected_parties() service to discover downstream teams from lineage
- Add POST /proposals/{id}/object endpoint for non-blocking objections
- Update proposal response model with AffectedAsset, AffectedTeam, Objection types
- Add proposal detail template showing affected parties and objections
- Add comprehensive tests for affected parties and objections
- Add semver tests for version comparison

Registered consumers still require acknowledgment (hard block). Lineage-discovered teams can file visible objections but don't block publishing.