### PR TITLE
Bump version to 0.1.5 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tessera-contracts"
-version = "0.1.4"
+version = "0.1.5"
 description = "Data contract coordination for warehouses"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Fixes CI failure on v0.1.5 tag where PyPI publish failed because pyproject.toml still had version 0.1.4

## Context
The v0.1.5 tag was created but the version in pyproject.toml wasn't bumped, causing "File already exists" error when trying to publish to PyPI.

## Test plan
- CI should pass
- After merge, delete and re-create the v0.1.5 tag to trigger a fresh PyPI publish