### PR TITLE
feat: add max_length=100 validation to search query parameter (#219)

### DIFF
--- a/src/tessera/api/assets.py
+++ b/src/tessera/api/assets.py
@@ -460,7 +460,7 @@ async def list_assets(
 async def search_assets(
     request: Request,
     auth: Auth,
-    q: str = Query(..., min_length=1, description="Search query"),
+    q: str = Query(..., min_length=1, max_length=100, description="Search query"),
     owner: UUID | None = Query(None, description="Filter by owner team ID"),
     environment: str | None = Query(None, description="Filter by environment"),
     limit: int = Query(

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -289,7 +289,24 @@ class TestAssetSearch:
         data = resp.json()
         assert all(r["owner_team_id"] == team1_id for r in data["results"])
 
+    async def test_search_query_max_length_validation(self, client: AsyncClient):
+        """Search query exceeding 100 characters returns 422 error with appropriate message."""
+        long_query = "a" * 101
+        resp = await client.get(f"/api/v1/assets/search?q={long_query}")
 
+        assert resp.status_code == 422, f"Expected 422, got {resp.status_code}: {resp.json()}"
+
+        resp_data = resp.json()
+        error_detail = str(resp_data)
+        assert "string should have at most 100 characters" in error_detail.lower()
+
+    async def test_search_query_min_length_validation(self, client: AsyncClient):
+        """Empty search query returns 422 error (min_length=1 validation)."""
+        resp = await client.get("/api/v1/assets/search?q=")
+        assert resp.status_code == 422
+        resp_data = resp.json()
+        error_detail = str(resp_data)
+        assert "string should have at least 1 character" in error_detail.lower()
 class TestAssetDependencies:
     """Tests for asset dependencies endpoints."""
 


### PR DESCRIPTION
I've implemented the max length validation for the search query parameter as requested in Issue #219.

###What's Changed

1. Update src/tessera/api/assets.py: Add max_length=100 to the q query parameter in search_assets endpoint.
2. Add 2 tests in tests/test_assets.py (under TestAssetSearch class):
Validate 101-char query returns 422 error
Ensure empty query still triggers min_length=1 validation

### Manual Verification
- 101-char query → 422 with "string should have at most 100 characters"
- Empty query → 422 with min-length error
- Valid queries still work as expected