### PR TITLE
fix: replace broad Exception with specific exceptions (#223)

### DIFF
--- a/src/tessera/api/auth.py
+++ b/src/tessera/api/auth.py
@@ -80,7 +80,7 @@ async def _get_session_auth_context(
             api_key=mock_key,
             scopes=scopes,
         )
-    except Exception as e:
+    except ValueError as e:
         logger.debug(f"Session auth failed: {e}")
         return None
 

--- a/src/tessera/db/database.py
+++ b/src/tessera/db/database.py
@@ -29,6 +29,7 @@ import logging
 from collections.abc import AsyncGenerator
 
 from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -145,6 +146,6 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
         try:
             yield session
             await session.commit()
-        except Exception:
+        except (DBAPIError, IntegrityError, OperationalError):
             await session.rollback()
             raise

--- a/src/tessera/main.py
+++ b/src/tessera/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
+import redis
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
@@ -256,7 +257,7 @@ async def health(
     # Update gauge metrics while we have a session
     try:
         await update_gauge_metrics(session)
-    except Exception:
+    except (TimeoutError, redis.ConnectionError, redis.TimeoutError):
         pass  # Don't fail health check if metrics update fails
 
     return {

--- a/src/tessera/services/metrics.py
+++ b/src/tessera/services/metrics.py
@@ -6,6 +6,7 @@ Provides application metrics for monitoring and observability.
 import time
 from typing import Any
 
+import redis
 from prometheus_client import (
     REGISTRY,
     Counter,
@@ -232,6 +233,6 @@ async def update_gauge_metrics(session: Any) -> None:
         result = await session.execute(select(func.count(UserDB.id)))
         users_total.set(result.scalar_one())
 
-    except Exception:
+    except (TimeoutError, redis.ConnectionError, redis.TimeoutError):
         # Don't fail if we can't update metrics
         pass


### PR DESCRIPTION
Fixes #223 by replacing broad except Exception blocks with specific, context-appropriate exceptions. This improves debugging clarity and avoids hiding unexpected bugs.

### Changes Made

1. src/tessera/api/auth.py: Catch ValueError (instead of Exception) for UUID parsing failures
2. src/tessera/services/metrics.py: Catch Redis-related exceptions (redis.ConnectionError, redis.TimeoutError) and asyncio.TimeoutError
3. src/tessera/db/database.py: Catch SQLAlchemy database exceptions (DBAPIError, IntegrityError, OperationalError)
4. src/tessera/main.py: Catch Redis/timeout exceptions (consistent with metrics.py) for health check metric updates

### Verification

- All lint checks pass (uv run ruff check src/tessera/ --fix)
- Relevant tests pass:
tests/test_auth.py
tests/test_database.py 
tests/test_health.py 
