### PR TITLE
fix: normalize email addresses in UserCreate and API layer (#220)

### DIFF
--- a/src/tessera/models/user.py
+++ b/src/tessera/models/user.py
@@ -42,6 +42,12 @@ class UserCreate(UserBase):
     password: str | None = Field(None, min_length=4, max_length=128)
     role: UserRole = UserRole.USER
 
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        """Normalize email to lowercase and strip whitespace."""
+        return v.lower().strip()
+
 
 class UserUpdate(BaseModel):
     """Fields for updating a user."""


### PR DESCRIPTION
## Summary

This PR fixes issue #220 by normalizing email addresses:
- Adds `@field_validator` to `UserCreate` model to normalize emails (lowercase + strip whitespace)
- Based on original contribution from PR #244 by @ChanfeiLi

**Changes:**
- `src/tessera/models/user.py`: Added email normalization validator to `UserCreate`
- `src/tessera/api/auth.py`: Fixed import ordering for logging module

## Original Contributor

Based on PR #244 by @ChanfeiLi. This PR rebases the original work onto the latest main branch and fixes lint issues.

Closes #220
Supersedes #244