### PR TITLE
refactor: replace HTTPException with ForbiddenError in dependencies.py (#252)

### DIFF
--- a/src/tessera/api/dependencies.py
+++ b/src/tessera/api/dependencies.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -50,12 +50,9 @@ async def create_dependency(
         raise NotFoundError(ErrorCode.ASSET_NOT_FOUND, "Asset not found")
 
     if asset.owner_team_id != auth.team_id and not auth.has_scope(APIKeyScope.ADMIN):
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "code": "INSUFFICIENT_PERMISSIONS",
-                "message": "You can only add dependencies to assets belonging to your team",
-            },
+        raise ForbiddenError(
+            "You can only add dependencies to assets belonging to your team",
+            code=ErrorCode.UNAUTHORIZED_TEAM,
         )
 
     result = await session.execute(


### PR DESCRIPTION
Fixes #252 by replacing raw `HTTPException` with the standardized `ForbiddenError` in `src/tessera/api/dependencies.py`.

### Changes Made
1. **src/tessera/api/dependencies.py**: Replaced `HTTPException(status_code=403)` with `ForbiddenError`.
2. Updated the error code to `ErrorCode.UNAUTHORIZED_TEAM` (the correct existing enum) instead of the suggested non-existent `INSUFFICIENT_PERMISSIONS`.

### Verification
* All lint checks pass (`uv run ruff check`, `uv run ruff format`, `uv run mypy`).
* Full test suite passed (`uv run pytest`).