### PR TITLE
fix: standardize error handling by replacing HTTPException with custom error classes

### DIFF
--- a/src/tessera/api/errors.py
+++ b/src/tessera/api/errors.py
@@ -23,6 +23,7 @@ class ErrorCode(StrEnum):
     REGISTRATION_NOT_FOUND = "REGISTRATION_NOT_FOUND"
     DEPENDENCY_NOT_FOUND = "DEPENDENCY_NOT_FOUND"
     API_KEY_NOT_FOUND = "API_KEY_NOT_FOUND"
+    USER_NOT_FOUND = "USER_NOT_FOUND"
     SYNC_PATH_NOT_FOUND = "SYNC_PATH_NOT_FOUND"
     MANIFEST_NOT_FOUND = "MANIFEST_NOT_FOUND"
 
@@ -53,6 +54,15 @@ class ErrorCode(StrEnum):
     CONTRACT_NOT_ACTIVE = "CONTRACT_NOT_ACTIVE"
     UNAUTHORIZED_TEAM = "UNAUTHORIZED_TEAM"
     INVALID_INPUT = "INVALID_INPUT"
+    TEAM_HAS_ASSETS = "TEAM_HAS_ASSETS"
+    SAME_TEAM = "SAME_TEAM"
+    INSUFFICIENT_PERMISSIONS = "INSUFFICIENT_PERMISSIONS"
+    USER_TEAM_MISMATCH = "USER_TEAM_MISMATCH"
+    AUDIT_REQUIRED = "AUDIT_REQUIRED"
+    AUDIT_FAILED = "AUDIT_FAILED"
+    VERSION_EXISTS = "VERSION_EXISTS"
+    CONFLICT_MODE_INVALID = "CONFLICT_MODE_INVALID"
+    SYNC_CONFLICT = "SYNC_CONFLICT"
 
     # Auth errors
     UNAUTHORIZED = "UNAUTHORIZED"
@@ -109,6 +119,18 @@ class DuplicateError(APIError):
         super().__init__(code, message, status_code=409, details=details)
 
 
+class ConflictError(APIError):
+    """Conflict error (409) for non-duplicate conflicts."""
+
+    def __init__(
+        self,
+        code: ErrorCode,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ):
+        super().__init__(code, message, status_code=409, details=details)
+
+
 class BadRequestError(APIError):
     """Bad request error."""
 
@@ -148,6 +170,18 @@ class ForbiddenError(APIError):
         super().__init__(code, message, status_code=403, details=details)
         if extra:
             self.details.update(extra)
+
+
+class PreconditionFailedError(APIError):
+    """Precondition failed error (412)."""
+
+    def __init__(
+        self,
+        code: ErrorCode,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ):
+        super().__init__(code, message, status_code=412, details=details)
 
 
 class RequestIDMiddleware(BaseHTTPMiddleware):

--- a/src/tessera/api/teams.py
+++ b/src/tessera/api/teams.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -12,6 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from tessera.api.auth import Auth, RequireAdmin, RequireRead
 from tessera.api.errors import (
+    BadRequestError,
+    ConflictError,
     DuplicateError,
     ErrorCode,
     NotFoundError,
@@ -219,13 +221,10 @@ async def delete_team(
     asset_count = asset_count_result.scalar() or 0
 
     if asset_count > 0 and not force:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "code": "TEAM_HAS_ASSETS",
-                "message": f"Team owns {asset_count} asset(s). Reassign or use force=true.",
-                "asset_count": asset_count,
-            },
+        raise ConflictError(
+            ErrorCode.TEAM_HAS_ASSETS,
+            f"Team owns {asset_count} asset(s). Reassign or use force=true.",
+            details={"asset_count": asset_count},
         )
 
     team.deleted_at = datetime.now(UTC)
@@ -295,7 +294,7 @@ async def list_team_members(
     )
     team = result.scalar_one_or_none()
     if not team:
-        raise HTTPException(status_code=404, detail="Team not found")
+        raise NotFoundError(ErrorCode.TEAM_NOT_FOUND, "Team not found")
 
     # Build query for team members
     base_query = (
@@ -349,7 +348,7 @@ async def reassign_team_assets(
     )
     source_team = source_result.scalar_one_or_none()
     if not source_team:
-        raise HTTPException(status_code=404, detail="Source team not found")
+        raise NotFoundError(ErrorCode.TEAM_NOT_FOUND, "Source team not found")
 
     # Verify target team exists
     target_result = await session.execute(
@@ -359,10 +358,10 @@ async def reassign_team_assets(
     )
     target_team = target_result.scalar_one_or_none()
     if not target_team:
-        raise HTTPException(status_code=404, detail="Target team not found")
+        raise NotFoundError(ErrorCode.TEAM_NOT_FOUND, "Target team not found")
 
     if team_id == reassign.target_team_id:
-        raise HTTPException(status_code=400, detail="Source and target team cannot be the same")
+        raise BadRequestError("Source and target team cannot be the same", code=ErrorCode.SAME_TEAM)
 
     # Build query for assets to reassign
     query = (


### PR DESCRIPTION
## Summary

- Replace FastAPI HTTPException with custom error classes across API modules for consistent error response format
- Add new error codes: USER_TEAM_MISMATCH, AUDIT_REQUIRED, AUDIT_FAILED, VERSION_EXISTS, CONFLICT_MODE_INVALID, SYNC_CONFLICT  
- Add PreconditionFailedError class for 412 responses
- All error responses now include structured format with error codes, request IDs, and timestamps

## Files Changed

- `src/tessera/api/errors.py` - Added new error codes and PreconditionFailedError class
- `src/tessera/api/assets.py` - Replaced HTTPExceptions with typed custom errors
- `src/tessera/api/dependencies.py` - Replaced HTTPExceptions with typed custom errors
- `src/tessera/api/sync.py` - Replaced HTTPExceptions with typed custom errors
- `src/tessera/api/teams.py` - Replaced HTTPExceptions with typed custom errors
- `src/tessera/api/users.py` - Replaced HTTPExceptions with typed custom errors

## Test plan

- [x] All 816 tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes

Closes #227