### PR TITLE
feat: add name validation to APIKeyCreate (#266)

### DIFF
--- a/src/tessera/models/api_key.py
+++ b/src/tessera/models/api_key.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from tessera.models.enums import APIKeyScope
 
@@ -20,6 +20,15 @@ class APIKeyCreate(BaseModel):
         description="Permission scopes for this key",
     )
     expires_at: datetime | None = Field(None, description="Optional expiration time")
+
+    @field_validator("name")
+    @classmethod
+    def validate_and_strip_name(cls, v: str) -> str:
+        """Strip whitespace and validate API key name."""
+        v = v.strip()
+        if not v:
+            raise ValueError("API key name cannot be empty or whitespace only")
+        return v
 
 
 class APIKeyCreated(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -2622,7 +2622,7 @@ wheels = [
 
 [[package]]
 name = "tessera-contracts"
-version = "0.1.4"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Adds name validation to the `APIKeyCreate` model to ensure API key names are not empty or whitespace-only, consistent with other models like `Team`.

### Changes Made
- Added `@field_validator("name")` to `APIKeyCreate` in `src/tessera/models/api_key.py`.
- Implemented `validate_and_strip_name` to strip whitespace and check for empty strings.

### Verification
- Verified empty names are rejected and valid names are stripped.
- Lint checks passed (`uv run ruff check`).

Closes #266