### PR TITLE
feat: create batch fetch utility for N+1 query prevention

### DIFF
--- a/src/tessera/services/__init__.py
+++ b/src/tessera/services/__init__.py
@@ -12,6 +12,11 @@ from tessera.services.audit import (
     log_proposal_force_approved,
     log_proposal_rejected,
 )
+from tessera.services.batch import (
+    fetch_asset_counts_by_team,
+    fetch_asset_counts_by_user,
+    fetch_team_names,
+)
 from tessera.services.graphql import (
     AssetFromGraphQL,
     GraphQLOperation,
@@ -47,6 +52,10 @@ from tessera.services.schema_validator import (
 __all__ = [
     # Affected parties
     "get_affected_parties",
+    # Batch fetching
+    "fetch_asset_counts_by_team",
+    "fetch_asset_counts_by_user",
+    "fetch_team_names",
     # Schema diffing
     "BreakingChange",
     "SchemaDiff",

--- a/src/tessera/services/batch.py
+++ b/src/tessera/services/batch.py
@@ -1,0 +1,75 @@
+"""Batch fetch utilities to prevent N+1 queries."""
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tessera.db import AssetDB, TeamDB
+
+
+async def fetch_asset_counts_by_team(
+    session: AsyncSession,
+    team_ids: list[UUID],
+) -> dict[UUID, int]:
+    """Fetch asset counts for multiple teams in a single query.
+
+    Args:
+        session: Database session
+        team_ids: List of team IDs to fetch counts for
+
+    Returns:
+        Dictionary mapping team ID to asset count
+    """
+    if not team_ids:
+        return {}
+    result = await session.execute(
+        select(AssetDB.owner_team_id, func.count(AssetDB.id))
+        .where(AssetDB.owner_team_id.in_(team_ids))
+        .where(AssetDB.deleted_at.is_(None))
+        .group_by(AssetDB.owner_team_id)
+    )
+    return {team_id: count for team_id, count in result.all()}
+
+
+async def fetch_asset_counts_by_user(
+    session: AsyncSession,
+    user_ids: list[UUID],
+) -> dict[UUID, int]:
+    """Fetch asset counts for multiple users in a single query.
+
+    Args:
+        session: Database session
+        user_ids: List of user IDs to fetch counts for
+
+    Returns:
+        Dictionary mapping user ID to asset count
+    """
+    if not user_ids:
+        return {}
+    result = await session.execute(
+        select(AssetDB.owner_user_id, func.count(AssetDB.id))
+        .where(AssetDB.owner_user_id.in_(user_ids))
+        .where(AssetDB.deleted_at.is_(None))
+        .group_by(AssetDB.owner_user_id)
+    )
+    return {user_id: count for user_id, count in result.all()}
+
+
+async def fetch_team_names(
+    session: AsyncSession,
+    team_ids: list[UUID],
+) -> dict[UUID, str]:
+    """Fetch team names for multiple teams in a single query.
+
+    Args:
+        session: Database session
+        team_ids: List of team IDs to fetch names for
+
+    Returns:
+        Dictionary mapping team ID to team name
+    """
+    if not team_ids:
+        return {}
+    result = await session.execute(select(TeamDB.id, TeamDB.name).where(TeamDB.id.in_(team_ids)))
+    return {tid: name for tid, name in result.all()}


### PR DESCRIPTION
## Summary
- Add `src/tessera/services/batch.py` with reusable batch fetch utilities to prevent N+1 queries
- Extract duplicated batch fetching logic from `teams.py` and `users.py` into shared helpers

## Changes
- **New file**: `src/tessera/services/batch.py` with three helpers:
  - `fetch_asset_counts_by_team(session, team_ids)` - batch fetch asset counts by team
  - `fetch_asset_counts_by_user(session, user_ids)` - batch fetch asset counts by user  
  - `fetch_team_names(session, team_ids)` - batch fetch team names
- **Updated**: `src/tessera/api/teams.py` - uses `fetch_asset_counts_by_team`
- **Updated**: `src/tessera/api/users.py` - uses `fetch_team_names` and `fetch_asset_counts_by_user`
- **Updated**: `src/tessera/services/__init__.py` - exports batch functions

## Test plan
- [x] All 816 tests pass
- [x] Ruff linting passes
- [x] Mypy type checking passes

Closes #271