### PR TITLE
fix: skip uvloop installation on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ dev = [
     "types-jsonschema>=4.25.1.20251009",
     "types-pyyaml>=6.0.12.20250915",
     "types-redis>=4.6.0,<5.0.0",
-    "uvloop>=0.22.0,<1.0.0",
+    "uvloop>=0.22.0,<1.0.0; sys_platform != 'win32'",
     "httptools>=0.7.0,<1.0.0",
     "watchfiles>=1.0.0,<2.0.0",
     "duckdb>=1.0.0,<2.0.0",


### PR DESCRIPTION
## Summary
- Add platform marker to uvloop dependency so it only installs on non-Windows systems
- Fixes `RuntimeError: uvloop does not support Windows at the moment` when running tests on Windows

## Changes
- `pyproject.toml`: Added `; sys_platform != 'win32'` marker to uvloop dependency

## Context
Reported in #261 - a contributor on Windows couldn't run `uv run mypy` because pytest-asyncio auto-detects uvloop and tries to use it as the event loop.