### PR TITLE
feat: standardize pagination across all list endpoints (#232)

### DIFF
--- a/src/tessera/api/registrations.py
+++ b/src/tessera/api/registrations.py
@@ -3,7 +3,7 @@
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, Query, Request, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -77,6 +77,7 @@ async def create_registration(
 @limit_read
 async def list_registrations(
     request: Request,
+    response: Response,
     auth: Auth,
     consumer_team_id: UUID | None = Query(None, description="Filter by consumer team ID"),
     contract_id: UUID | None = Query(None, description="Filter by contract ID"),
@@ -87,7 +88,7 @@ async def list_registrations(
 ) -> dict[str, Any]:
     """List all registrations with filtering and pagination.
 
-    Requires read scope.
+    Requires read scope. Returns X-Total-Count header with total count.
     """
     query = select(RegistrationDB)
     if consumer_team_id:
@@ -98,7 +99,7 @@ async def list_registrations(
         query = query.where(RegistrationDB.status == status)
     query = query.order_by(RegistrationDB.registered_at.desc())
 
-    return await paginate(session, query, params, response_model=Registration)
+    return await paginate(session, query, params, response_model=Registration, response=response)
 
 
 @router.get("/{registration_id}", response_model=Registration)


### PR DESCRIPTION
## Summary
- Standardizes pagination parameters across all list endpoints to use `PaginationParams` dependency
- Updates `proposals.py`, `webhooks.py`, and `audit.py` to use the shared pagination dependency
- Adds `X-Total-Count` header support for paginated responses
- Updates `registrations` and `dependencies` endpoints to return the header

## Changes
- **proposals.py**: Replaced inline `limit`/`offset` params with `PaginationParams = Depends(pagination_params)`
- **webhooks.py**: Same change, also added `limit`/`offset` to response model
- **audit.py**: Same change for both `list_audit_events` and `get_entity_history`
- **pagination.py**: Added `set_total_count_header()` helper and updated `paginate()` to accept optional `Response`
- **registrations.py**: Added `Response` param to set `X-Total-Count` header
- **dependencies.py**: Same as registrations

## Test plan
- [x] All 817 tests pass
- [x] Linting passes
- [ ] Verify X-Total-Count header in response when calling list endpoints

Closes #232