### PR TITLE
chore: remove dead code from metrics module

### DIFF
--- a/src/tessera/services/metrics.py
+++ b/src/tessera/services/metrics.py
@@ -3,6 +3,7 @@
 Provides application metrics for monitoring and observability.
 """
 
+import re
 import time
 from typing import Any
 
@@ -91,14 +92,6 @@ users_total = Gauge(
     "Total number of users",
 )
 
-# Database metrics
-db_query_duration_seconds = Histogram(
-    "tessera_db_query_duration_seconds",
-    "Database query duration in seconds",
-    ["operation"],
-    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0),
-)
-
 # Application info
 app_info = Gauge(
     "tessera_app_info",
@@ -132,8 +125,6 @@ def _normalize_path(path: str) -> str:
 
     Replaces UUIDs and numeric IDs with placeholders.
     """
-    import re
-
     # Replace UUIDs
     path = re.sub(
         r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
@@ -177,22 +168,6 @@ class MetricsMiddleware(BaseHTTPMiddleware):
             http_requests_in_progress.labels(method=method, endpoint=path).dec()
 
         return response
-
-
-# Helper functions for recording business metrics
-def record_contract_published(change_type: str = "patch") -> None:
-    """Record a contract publication."""
-    contracts_published_total.labels(change_type=change_type).inc()
-
-
-def record_proposal_created() -> None:
-    """Record a proposal creation."""
-    proposals_created_total.inc()
-
-
-def record_proposal_acknowledged(response: str) -> None:
-    """Record a proposal acknowledgment."""
-    proposals_acknowledged_total.labels(response=response).inc()
 
 
 async def update_gauge_metrics(session: Any) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -157,38 +157,6 @@ class TestMetricsService:
         normalized = _normalize_path(path)
         assert normalized == "/api/v1/teams/{id}/assets/{id}"
 
-    def test_record_contract_published(self):
-        """Test recording contract publication."""
-        from tessera.services.metrics import contracts_published_total, record_contract_published
-
-        # Get initial value
-        initial = contracts_published_total.labels(change_type="minor")._value.get()
-
-        record_contract_published("minor")
-
-        # Value should have incremented
-        new_value = contracts_published_total.labels(change_type="minor")._value.get()
-        assert new_value == initial + 1
-
-    def test_record_proposal_created(self):
-        """Test recording proposal creation."""
-        from tessera.services.metrics import proposals_created_total, record_proposal_created
-
-        initial = proposals_created_total._value.get()
-        record_proposal_created()
-        assert proposals_created_total._value.get() == initial + 1
-
-    def test_record_proposal_acknowledged(self):
-        """Test recording proposal acknowledgment."""
-        from tessera.services.metrics import (
-            proposals_acknowledged_total,
-            record_proposal_acknowledged,
-        )
-
-        initial = proposals_acknowledged_total.labels(response="accepted")._value.get()
-        record_proposal_acknowledged("accepted")
-        assert proposals_acknowledged_total.labels(response="accepted")._value.get() == initial + 1
-
     def test_get_metrics_returns_bytes(self):
         """Test that get_metrics returns bytes."""
         from tessera.services.metrics import get_metrics


### PR DESCRIPTION
## Summary
- Remove unused `db_query_duration_seconds` histogram that was never observed
- Remove unused helper functions (`record_contract_published`, `record_proposal_created`, `record_proposal_acknowledged`) that were never called in production code
- Move `re` import from function scope to module level for cleaner code organization
- Remove corresponding tests for deleted functions

## Test plan
- [x] All 826 tests pass
- [x] Linting passes (ruff check)
- [x] Type checking passes (mypy)
- [x] Pre-commit hooks pass