### PR TITLE
feat: add API endpoint to preview version suggestion without publishing

### DIFF
--- a/src/tessera/models/__init__.py
+++ b/src/tessera/models/__init__.py
@@ -26,7 +26,13 @@ from tessera.models.bulk import (
     BulkRegistrationRequest,
     BulkRegistrationResponse,
 )
-from tessera.models.contract import Contract, ContractCreate, Guarantees
+from tessera.models.contract import (
+    Contract,
+    ContractCreate,
+    Guarantees,
+    VersionSuggestion,
+    VersionSuggestionRequest,
+)
 from tessera.models.dependency import Dependency, DependencyCreate
 from tessera.models.enums import (
     AcknowledgmentResponseType,
@@ -78,6 +84,8 @@ __all__ = [
     "Contract",
     "ContractCreate",
     "Guarantees",
+    "VersionSuggestion",
+    "VersionSuggestionRequest",
     # Dependency
     "Dependency",
     "DependencyCreate",

--- a/src/tessera/models/contract.py
+++ b/src/tessera/models/contract.py
@@ -99,6 +99,16 @@ class Contract(ContractBase):
     published_by_user_id: UUID | None = None
 
 
+class VersionSuggestionRequest(BaseModel):
+    """Request body for previewing version suggestion without publishing."""
+
+    schema_def: dict[str, Any] = Field(..., alias="schema", description="JSON Schema definition")
+    schema_format: SchemaFormat = Field(
+        SchemaFormat.JSON_SCHEMA,
+        description="Schema format: 'json_schema' (default) or 'avro'",
+    )
+
+
 class VersionSuggestion(BaseModel):
     """Suggested version based on schema diff analysis.
 
@@ -120,4 +130,8 @@ class VersionSuggestion(BaseModel):
     )
     is_first_contract: bool = Field(
         False, description="True if this is the first contract for the asset"
+    )
+    breaking_changes: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="List of breaking changes detected in the schema diff",
     )


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/assets/{asset_id}/version-suggestion` endpoint that previews what version would be suggested for a schema change without creating any contracts or proposals
- Extend `VersionSuggestion` model with `breaking_changes` field to include detailed change information
- Add comprehensive test coverage for first contract, compatible changes, breaking changes, and edge cases

## Use Cases
- CI/CD pipelines can show "this change will bump version to 2.0.0" before PR merge
- UIs can preview version suggestions before users confirm publication

## Response Example
```json
{
  "suggested_version": "2.0.0",
  "current_version": "1.5.0",
  "change_type": "major",
  "reason": "Breaking change detected - major version bump required",
  "breaking_changes": [
    {"type": "property_removed", "path": "properties.email", "message": "Property 'email' was removed"}
  ],
  "is_first_contract": false
}
```

## Test Plan
- [x] First contract suggests 1.0.0
- [x] Compatible change (adding optional property) suggests minor bump
- [x] Breaking change (removing property) suggests major bump with breaking_changes details
- [x] Identical schema suggests patch bump
- [x] Adding required field detected as breaking
- [x] Invalid schema returns 400
- [x] Nonexistent asset returns 404
- [x] All 52 asset/contract tests pass

Closes #236