### PR TITLE
feat: pre-release versions skip proposal workflow

### DIFF
--- a/src/tessera/services/audit.py
+++ b/src/tessera/services/audit.py
@@ -104,6 +104,7 @@ async def log_contract_published(
     version: str,
     change_type: str | None = None,
     force: bool = False,
+    prerelease: bool = False,
 ) -> AuditEventDB:
     """Log a contract publication event."""
     action = AuditAction.CONTRACT_FORCE_PUBLISHED if force else AuditAction.CONTRACT_PUBLISHED
@@ -117,6 +118,7 @@ async def log_contract_published(
             "version": version,
             "change_type": change_type,
             "force": force,
+            "prerelease": prerelease,
         },
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -2622,7 +2622,7 @@ wheels = [
 
 [[package]]
 name = "tessera-contracts"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Pre-release versions (1.0.0-alpha, 1.0.0-rc.1) skip proposal workflow for breaking changes
- Graduation from pre-release to stable (1.0.0-alpha → 1.0.0) also skips proposals
- Added audit logging for pre-release publications

## Changes

### New Helpers (`api/assets.py`)
- `is_prerelease(version)` - Check if version has prerelease suffix
- `get_base_version(version)` - Extract X.Y.Z from version string  
- `is_graduation(current, new)` - Detect prerelease → release transitions

### Publishing Flow
- Breaking change in pre-release → publishes directly with message
- Graduation with breaking change → publishes directly with message
- Stable version breaking change → creates proposal (unchanged)

### Tests
- 10 new tests covering pre-release and graduation scenarios

## Test Plan

- [x] `test_accepts_alpha_version` - 1.0.0-alpha is valid
- [x] `test_accepts_beta_version` - 1.0.0-beta.1 is valid
- [x] `test_accepts_rc_version` - 1.0.0-rc.1 is valid
- [x] `test_accepts_build_metadata` - 1.0.0+build.123 is valid
- [x] `test_prerelease_skips_proposal_workflow` - Breaking change in prerelease publishes directly
- [x] `test_release_version_requires_proposal` - Stable versions still require proposals
- [x] `test_graduate_alpha_to_release_compatible` - Compatible graduation works
- [x] `test_graduate_rc_to_release_compatible` - RC graduation works
- [x] `test_graduate_with_breaking_change_skips_proposal` - Breaking graduation skips proposal
- [x] `test_different_base_version_not_graduation` - 1.0.0-alpha → 1.1.0 is not graduation

Closes #19, closes #229