### PR TITLE
perf: add composite indexes for common query patterns

### DIFF
--- a/alembic/versions/007_add_composite_query_indexes.py
+++ b/alembic/versions/007_add_composite_query_indexes.py
@@ -1,0 +1,62 @@
+"""Add composite indexes for common query patterns.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-01-24
+
+These indexes optimize frequently-used query patterns:
+- Finding pending proposals for an asset
+- Finding active contracts for an asset
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Create composite indexes for common query patterns."""
+    if _is_sqlite():
+        # SQLite syntax
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_proposal_asset_status "
+            "ON proposals (asset_id, status)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS idx_contract_asset_status "
+            "ON contracts (asset_id, status)"
+        )
+    else:
+        # PostgreSQL with schema
+        schema = "core"
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_proposal_asset_status "
+            f"ON {schema}.proposals (asset_id, status)"
+        )
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_contract_asset_status "
+            f"ON {schema}.contracts (asset_id, status)"
+        )
+
+
+def downgrade() -> None:
+    """Drop composite indexes."""
+    if _is_sqlite():
+        op.execute("DROP INDEX IF EXISTS idx_proposal_asset_status")
+        op.execute("DROP INDEX IF EXISTS idx_contract_asset_status")
+    else:
+        schema = "core"
+        op.execute(f"DROP INDEX IF EXISTS {schema}.idx_proposal_asset_status")
+        op.execute(f"DROP INDEX IF EXISTS {schema}.idx_contract_asset_status")

--- a/src/tessera/db/models.py
+++ b/src/tessera/db/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     DateTime,
     Enum,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -158,6 +159,9 @@ class ContractDB(Base):
         Uuid, ForeignKey("users.id"), nullable=True, index=True
     )  # Individual who published
 
+    # Composite index for finding active contracts by asset (common query pattern)
+    __table_args__ = (Index("idx_contract_asset_status", "asset_id", "status"),)
+
     # Relationships
     asset: Mapped["AssetDB"] = relationship(back_populates="contracts")
     registrations: Mapped[list["RegistrationDB"]] = relationship(back_populates="contract")
@@ -226,6 +230,9 @@ class ProposalDB(Base):
     affected_assets: Mapped[list[dict[str, Any]]] = mapped_column(JSON, default=list)
     # Objections filed by affected teams (non-blocking but visible)
     objections: Mapped[list[dict[str, Any]]] = mapped_column(JSON, default=list)
+
+    # Composite index for finding pending proposals by asset (common query pattern)
+    __table_args__ = (Index("idx_proposal_asset_status", "asset_id", "status"),)
 
     # Relationships
     asset: Mapped["AssetDB"] = relationship(back_populates="proposals")


### PR DESCRIPTION
## Summary

Closes #294

- Add composite indexes on `(asset_id, status)` for `proposals` and `contracts` tables
- Optimizes frequently-used query patterns for finding pending proposals and active contracts
- Alembic migration 007 supports both SQLite and PostgreSQL schemas

## Changes

- `alembic/versions/007_add_composite_query_indexes.py` - New migration with dialect detection
- `src/tessera/db/models.py` - Add `__table_args__` with Index definitions to ContractDB and ProposalDB

## Test Plan

- [x] All 23 contract tests pass
- [x] Migration handles SQLite (memory) and PostgreSQL (with schema prefix)
- [x] Downgrade path tested (DROP INDEX IF EXISTS)