### PR TITLE
fix(api): add max_length validation to global search query

### DIFF
--- a/src/tessera/api/search.py
+++ b/src/tessera/api/search.py
@@ -91,7 +91,7 @@ class SearchEntityType(str, Enum):
 @router.get("", response_model=SearchResponse)
 async def search(
     auth: Auth,
-    q: str = Query(..., min_length=1, description="Search query"),
+    q: str = Query(..., min_length=1, max_length=100, description="Search query"),
     limit: int = Query(10, ge=1, le=50, description="Max results per entity type"),
     types: list[SearchEntityType] | None = Query(None, description="Limit results to entity types"),
     _: None = RequireRead,

--- a/tests/test_search_validation.py
+++ b/tests/test_search_validation.py
@@ -1,0 +1,24 @@
+"""Tests for global search API validation."""
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSearchValidation:
+    """Tests for /api/v1/search parameter validation."""
+
+    async def test_search_query_too_long(self, client: AsyncClient) -> None:
+        """Search query exceeding max_length (100) returns 422."""
+        long_query = "a" * 101
+        response = await client.get(f"/api/v1/search?q={long_query}")
+        assert response.status_code == 422
+        expected_err = "String should have at most 100 characters"
+        assert expected_err in response.text or "less than or equal to 100" in response.text
+
+    async def test_search_query_max_length_ok(self, client: AsyncClient) -> None:
+        """Search query at max_length (100) is allowed."""
+        max_query = "a" * 100
+        response = await client.get(f"/api/v1/search?q={max_query}")
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

The global search endpoint was missing `max_length` validation, allowing potentially unbounded search strings. This PR adds a 100-character limit to match the asset search endpoint.

## Changes
- Add `max_length=100` to `q` parameter in `src/tessera/api/search.py`
- Add `tests/test_search_validation.py` to verify validation behavior

## Verification
- [x] New validation tests passed
- [x] Existing search tests passed
- [x] Ruff check passed

Fixes #260