### PR TITLE
fix: P0 data integrity, security, and publish path consolidation

### DIFF
--- a/alembic/versions/012_add_dependency_soft_delete.py
+++ b/alembic/versions/012_add_dependency_soft_delete.py
@@ -1,0 +1,80 @@
+"""Add soft delete support to dependencies.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-02-15
+
+Dependencies previously used hard delete, which destroyed lineage data
+and left no audit trail. This migration adds a deleted_at column to enable
+soft deletes consistent with teams, assets, users, and registrations.
+
+Also adds composite indexes on (source_asset_id, deleted_at) and
+(target_asset_id, deleted_at) to support filtered lineage queries.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "012"
+down_revision: str | None = "011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Add deleted_at column and indexes to dependencies."""
+    if _is_sqlite():
+        with op.batch_alter_table("dependencies") as batch_op:
+            batch_op.add_column(sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True))
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_dependencies_deleted_at ON dependencies (deleted_at)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_dependencies_source_deleted "
+            "ON dependencies (dependent_asset_id, deleted_at)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_dependencies_target_deleted "
+            "ON dependencies (dependency_asset_id, deleted_at)"
+        )
+    else:
+        op.add_column(
+            "dependencies",
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_dependencies_deleted_at ON dependencies (deleted_at)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_dependencies_source_deleted "
+            "ON dependencies (dependent_asset_id, deleted_at)"
+        )
+        op.execute(
+            "CREATE INDEX IF NOT EXISTS ix_dependencies_target_deleted "
+            "ON dependencies (dependency_asset_id, deleted_at)"
+        )
+
+
+def downgrade() -> None:
+    """Remove deleted_at column and indexes from dependencies."""
+    if _is_sqlite():
+        op.execute("DROP INDEX IF EXISTS ix_dependencies_target_deleted")
+        op.execute("DROP INDEX IF EXISTS ix_dependencies_source_deleted")
+        op.execute("DROP INDEX IF EXISTS ix_dependencies_deleted_at")
+        with op.batch_alter_table("dependencies") as batch_op:
+            batch_op.drop_column("deleted_at")
+    else:
+        op.execute("DROP INDEX IF EXISTS ix_dependencies_target_deleted")
+        op.execute("DROP INDEX IF EXISTS ix_dependencies_source_deleted")
+        op.execute("DROP INDEX IF EXISTS ix_dependencies_deleted_at")
+        op.drop_column("dependencies", "deleted_at")

--- a/src/tessera/api/impact.py
+++ b/src/tessera/api/impact.py
@@ -69,6 +69,7 @@ async def get_downstream_assets_recursive(
             select(AssetDB, AssetDependencyDB.dependency_type)
             .join(AssetDependencyDB, AssetDependencyDB.dependent_asset_id == AssetDB.id)
             .where(AssetDependencyDB.dependency_asset_id.in_(current_ids))
+            .where(AssetDependencyDB.deleted_at.is_(None))
             .where(AssetDB.deleted_at.is_(None))
         )
         deps_result = await session.execute(deps_query)

--- a/src/tessera/api/schemas.py
+++ b/src/tessera/api/schemas.py
@@ -2,18 +2,30 @@
 
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from tessera.api.auth import Auth, RequireRead
+from tessera.api.rate_limit import limit_read
+from tessera.db import get_session
 from tessera.services import check_schema_validity
 
 router = APIRouter()
 
 
 @router.post("/validate")
-async def validate_schema(schema: dict[str, Any]) -> dict[str, Any]:
+@limit_read
+async def validate_schema(
+    request: Request,
+    schema: dict[str, Any],
+    auth: Auth,
+    _: None = RequireRead,
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
     """Validate a JSON Schema.
 
     Checks whether the provided dictionary is a valid JSON Schema (Draft 7).
+    Requires read scope. Rate-limited to prevent CPU abuse from deeply nested schemas.
 
     Returns:
         - valid: boolean indicating if the schema is valid

--- a/src/tessera/db/models.py
+++ b/src/tessera/db/models.py
@@ -331,6 +331,9 @@ class AssetDependencyDB(Base):
         Enum(DependencyType), default=DependencyType.CONSUMES
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
 
     __table_args__ = (
         UniqueConstraint(

--- a/src/tessera/db/queries.py
+++ b/src/tessera/db/queries.py
@@ -1,0 +1,24 @@
+"""Query helpers that enforce soft-delete filtering.
+
+Use these helpers as the starting point for queries against soft-deletable
+models to ensure deleted records are never accidentally included.
+"""
+
+from sqlalchemy import Select, select
+
+from tessera.db.models import AssetDB, RegistrationDB, TeamDB
+
+
+def active_assets() -> Select[tuple[AssetDB]]:
+    """Base query for non-deleted assets."""
+    return select(AssetDB).where(AssetDB.deleted_at.is_(None))
+
+
+def active_registrations() -> Select[tuple[RegistrationDB]]:
+    """Base query for non-deleted registrations."""
+    return select(RegistrationDB).where(RegistrationDB.deleted_at.is_(None))
+
+
+def active_teams() -> Select[tuple[TeamDB]]:
+    """Base query for non-deleted teams."""
+    return select(TeamDB).where(TeamDB.deleted_at.is_(None))

--- a/src/tessera/models/user.py
+++ b/src/tessera/models/user.py
@@ -39,7 +39,7 @@ class UserCreate(UserBase):
     """Fields for creating a user."""
 
     team_id: UUID | None = None
-    password: str | None = Field(None, min_length=4, max_length=128)
+    password: str | None = Field(None, min_length=8, max_length=128)
     role: UserRole = UserRole.USER
 
     @field_validator("email")
@@ -55,7 +55,7 @@ class UserUpdate(BaseModel):
     email: EmailStr | None = None
     name: str | None = Field(None, min_length=1, max_length=255)
     team_id: UUID | None = None
-    password: str | None = Field(None, min_length=4, max_length=128)
+    password: str | None = Field(None, min_length=8, max_length=128)
     role: UserRole | None = None
     notification_preferences: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = None

--- a/tests/test_authorization_gaps.py
+++ b/tests/test_authorization_gaps.py
@@ -219,9 +219,10 @@ class TestScopeRestrictions:
             session, "writer", [APIKeyScope.READ, APIKeyScope.WRITE]
         )
 
-        # /sync/dbt requires admin scope
+        # /sync/dbt/upload requires admin scope
         response = await client.post(
-            f"/api/v1/sync/dbt?manifest_path=/tmp/test.json&owner_team_id={team.id}",
+            "/api/v1/sync/dbt/upload",
+            json={"manifest": {}, "owner_team_id": str(team.id)},
             headers={"Authorization": f"Bearer {key}"},
         )
         assert response.status_code == 403


### PR DESCRIPTION
## Summary

Implements four P0 remediation specs identified during comprehensive code review:

- **Soft-delete filter enforcement**: 13 queries across contracts, proposals, dependencies, and affected parties were operating on logically-deleted records. Added `deleted_at IS NULL` filters and created `db/queries.py` with reusable helpers.

- **Dependency lifecycle**: Dependencies were the only entity using hard-delete with no audit trail. Converted to soft-delete, added migration 012, added `DEPENDENCY_CREATED`/`DEPENDENCY_DELETED` audit actions with full paper trail.

- **Publishing path consolidation**: Two independent publish implementations had diverged — the inline path in `assets.py` lacked `FOR UPDATE` locking (race condition for concurrent publishes) and didn't log guarantee changes. Refactored to delegate to `ContractPublishingWorkflow`, removing ~430 lines of duplicated logic.

- **Security hardening**: Removed `sync_from_dbt` endpoint (server-side path traversal via `manifest_path`). Scoped `auto_delete` by `owner_team_id` to prevent cross-tenant deletion. Elevated `force_proposal` to require ADMIN scope. Added auth/rate-limiting to `validate_schema`. Increased password minimum to 8 chars. Blocked insecure session secret in staging.

## Test plan

- [ ] 975 existing tests pass (verified)
- [ ] ruff check, ruff format, mypy all clean (verified)
- [ ] All pre-commit hooks pass (verified)
- [ ] Verify soft-deleted assets/registrations excluded from all query paths
- [ ] Verify dependency deletion creates audit event and preserves row
- [ ] Verify concurrent contract publishes are serialized (PostgreSQL)
- [ ] Verify `auto_delete` only affects requesting team's assets
- [ ] Verify WRITE-scoped key cannot force-approve proposals