### PR TITLE
fix: database schema hardening

### DIFF
--- a/alembic/versions/013_schema_hardening.py
+++ b/alembic/versions/013_schema_hardening.py
@@ -1,0 +1,167 @@
+"""Schema hardening: updated_at, audit indexes, FKs, timezone fix.
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-02-15
+
+Additive-only changes:
+
+1. Add ``updated_at`` column (nullable, onupdate) to 7 mutable models:
+   assets, teams, users, contracts, registrations, proposals, api_keys.
+   Immutable tables (audit_events, acknowledgments, dependencies,
+   webhook_deliveries, audit_runs) are intentionally excluded.
+
+2. Add indexes on audit_events for time-range and actor queries:
+   - occurred_at (B-tree for range scans)
+   - actor_id (equality lookups)
+   - (entity_type, occurred_at) composite for filtered time-range queries
+
+3. Add FK constraints (PostgreSQL only) on contracts.published_by and
+   proposals.proposed_by pointing to teams.id.  SQLite cannot add FKs
+   after table creation, and tests use create_all which picks up the
+   model-level ForeignKey already.
+
+4. Fix DateTime columns created by migration 001 from TIMESTAMP to
+   TIMESTAMPTZ (PostgreSQL only).  The ALTER uses ``USING col AT TIME
+   ZONE 'UTC'`` so existing naive timestamps are correctly reinterpreted.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "013"
+down_revision: str | None = "012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Tables that get updated_at
+_MUTABLE_TABLES = [
+    "assets",
+    "teams",
+    "users",
+    "contracts",
+    "registrations",
+    "proposals",
+    "api_keys",
+]
+
+# Columns from migration 001 that were created as TIMESTAMP (no timezone).
+# Format: (table_name, column_name)
+_TIMESTAMP_COLUMNS = [
+    ("teams", "created_at"),
+    ("assets", "created_at"),
+    ("contracts", "published_at"),
+    ("registrations", "registered_at"),
+    ("registrations", "acknowledged_at"),
+    ("dependencies", "created_at"),
+    ("proposals", "proposed_at"),
+    ("proposals", "resolved_at"),
+    ("acknowledgments", "migration_deadline"),
+    ("acknowledgments", "responded_at"),
+    ("audit_events", "occurred_at"),
+]
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Add updated_at columns, audit indexes, FK constraints, and fix timezone."""
+    is_sqlite = _is_sqlite()
+
+    # 1. Add updated_at to mutable tables
+    if is_sqlite:
+        for table in _MUTABLE_TABLES:
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.add_column(
+                    sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True)
+                )
+    else:
+        for table in _MUTABLE_TABLES:
+            op.add_column(
+                table,
+                sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            )
+
+    # 2. Audit indexes (both dialects)
+    op.create_index(
+        "ix_audit_events_occurred_at",
+        "audit_events",
+        ["occurred_at"],
+    )
+    op.create_index(
+        "ix_audit_events_actor_id",
+        "audit_events",
+        ["actor_id"],
+    )
+    op.create_index(
+        "ix_audit_events_entity_type_occurred_at",
+        "audit_events",
+        ["entity_type", "occurred_at"],
+    )
+
+    # 3. FK constraints (PostgreSQL only — SQLite can't add FKs post-creation)
+    if not is_sqlite:
+        op.execute(
+            "ALTER TABLE contracts "
+            "ADD CONSTRAINT fk_contracts_published_by_teams "
+            "FOREIGN KEY (published_by) REFERENCES teams(id)"
+        )
+        op.execute(
+            "ALTER TABLE proposals "
+            "ADD CONSTRAINT fk_proposals_proposed_by_teams "
+            "FOREIGN KEY (proposed_by) REFERENCES teams(id)"
+        )
+
+    # 4. Fix TIMESTAMP → TIMESTAMPTZ (PostgreSQL only)
+    if not is_sqlite:
+        for table, column in _TIMESTAMP_COLUMNS:
+            op.execute(
+                f"ALTER TABLE {table} "
+                f"ALTER COLUMN {column} "
+                f"TYPE TIMESTAMPTZ USING {column} AT TIME ZONE 'UTC'"
+            )
+
+
+def downgrade() -> None:
+    """Reverse schema hardening changes."""
+    is_sqlite = _is_sqlite()
+
+    # 4. Revert TIMESTAMPTZ → TIMESTAMP (PostgreSQL only)
+    if not is_sqlite:
+        for table, column in _TIMESTAMP_COLUMNS:
+            op.execute(
+                f"ALTER TABLE {table} "
+                f"ALTER COLUMN {column} "
+                f"TYPE TIMESTAMP USING {column} AT TIME ZONE 'UTC'"
+            )
+
+    # 3. Drop FK constraints (PostgreSQL only)
+    if not is_sqlite:
+        op.execute(
+            "ALTER TABLE proposals " "DROP CONSTRAINT IF EXISTS fk_proposals_proposed_by_teams"
+        )
+        op.execute(
+            "ALTER TABLE contracts " "DROP CONSTRAINT IF EXISTS fk_contracts_published_by_teams"
+        )
+
+    # 2. Drop audit indexes
+    op.drop_index("ix_audit_events_entity_type_occurred_at", table_name="audit_events")
+    op.drop_index("ix_audit_events_actor_id", table_name="audit_events")
+    op.drop_index("ix_audit_events_occurred_at", table_name="audit_events")
+
+    # 1. Drop updated_at columns
+    if is_sqlite:
+        for table in reversed(_MUTABLE_TABLES):
+            with op.batch_alter_table(table) as batch_op:
+                batch_op.drop_column("updated_at")
+    else:
+        for table in reversed(_MUTABLE_TABLES):
+            op.drop_column(table, "updated_at")

--- a/alembic/versions/014_partial_unique_constraints.py
+++ b/alembic/versions/014_partial_unique_constraints.py
@@ -1,0 +1,92 @@
+"""Convert global unique constraints to partial unique indexes.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-02-15
+
+Tables with soft-delete (deleted_at) have global unique constraints that
+prevent re-creating a record after it has been soft-deleted.  For example,
+soft-deleting a team named "analytics" and then creating a new team with
+the same name would fail.
+
+This migration converts 4 unique constraints to partial unique indexes
+with ``WHERE deleted_at IS NULL`` so that uniqueness is only enforced
+among live (non-deleted) rows.
+
+PostgreSQL only — SQLite does not support partial indexes via ALTER TABLE
+and cannot drop named constraints.  The global constraints created by
+``create_all`` in SQLite tests remain unchanged.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# (table, constraint_name, columns, partial_index_name)
+_CONSTRAINTS = [
+    (
+        "registrations",
+        "uq_registration_contract_consumer",
+        "contract_id, consumer_team_id",
+        "uq_registration_contract_consumer_live",
+    ),
+    (
+        "assets",
+        "uq_asset_fqn_environment",
+        "fqn, environment",
+        "uq_asset_fqn_environment_live",
+    ),
+    (
+        "dependencies",
+        "uq_dependency_edge",
+        "dependent_asset_id, dependency_asset_id, dependency_type",
+        "uq_dependency_edge_live",
+    ),
+    (
+        "teams",
+        "teams_name_key",
+        "name",
+        "uq_teams_name_live",
+    ),
+]
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Replace global unique constraints with partial unique indexes."""
+    if _is_sqlite():
+        # SQLite: no-op. Global constraints from create_all remain.
+        return
+
+    for table, constraint, columns, partial_idx in _CONSTRAINTS:
+        # Drop the global constraint first
+        op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint}")
+        # Create partial unique index on live rows only
+        op.execute(
+            f"CREATE UNIQUE INDEX {partial_idx} "
+            f"ON {table} ({columns}) "
+            f"WHERE deleted_at IS NULL"
+        )
+
+
+def downgrade() -> None:
+    """Restore global unique constraints from partial indexes."""
+    if _is_sqlite():
+        return
+
+    for table, constraint, columns, partial_idx in _CONSTRAINTS:
+        # Drop partial index
+        op.execute(f"DROP INDEX IF EXISTS {partial_idx}")
+        # Re-create global constraint
+        op.execute(f"ALTER TABLE {table} " f"ADD CONSTRAINT {constraint} UNIQUE ({columns})")

--- a/src/tessera/models/asset.py
+++ b/src/tessera/models/asset.py
@@ -83,6 +83,7 @@ class Asset(BaseModel):
     semver_mode: SemverMode = SemverMode.AUTO
     metadata: dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_")
     created_at: datetime
+    updated_at: datetime | None = None
 
 
 class AssetWithOwners(Asset):

--- a/src/tessera/models/contract.py
+++ b/src/tessera/models/contract.py
@@ -97,6 +97,7 @@ class Contract(ContractBase):
     published_at: datetime
     published_by: UUID
     published_by_user_id: UUID | None = None
+    updated_at: datetime | None = None
 
 
 class VersionSuggestionRequest(BaseModel):

--- a/src/tessera/models/proposal.py
+++ b/src/tessera/models/proposal.py
@@ -98,6 +98,7 @@ class Proposal(ProposalBase):
     resolved_at: datetime | None = None
     expires_at: datetime | None = None
     auto_expire: bool = False
+    updated_at: datetime | None = None
 
     # Affected parties discovered via lineage (not registered consumers)
     affected_teams: list[AffectedTeam] = Field(

--- a/src/tessera/models/registration.py
+++ b/src/tessera/models/registration.py
@@ -42,3 +42,4 @@ class Registration(RegistrationBase):
     status: RegistrationStatus = RegistrationStatus.ACTIVE
     registered_at: datetime
     acknowledged_at: datetime | None = None
+    updated_at: datetime | None = None

--- a/src/tessera/models/team.py
+++ b/src/tessera/models/team.py
@@ -56,3 +56,4 @@ class Team(BaseModel):
     name: str
     metadata: dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_")
     created_at: datetime
+    updated_at: datetime | None = None

--- a/src/tessera/models/user.py
+++ b/src/tessera/models/user.py
@@ -74,6 +74,7 @@ class User(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict, validation_alias="metadata_")
     notification_preferences: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
+    updated_at: datetime | None = None
     deactivated_at: datetime | None = None
 
 

--- a/tests/test_schema_hardening.py
+++ b/tests/test_schema_hardening.py
@@ -1,0 +1,260 @@
+"""Tests for schema hardening: updated_at, audit indexes, soft-delete re-creation."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tessera.db.models import (
+    AssetDB,
+    AuditEventDB,
+    ContractDB,
+    RegistrationDB,
+    TeamDB,
+)
+from tessera.models.enums import (
+    CompatibilityMode,
+    ContractStatus,
+)
+
+
+async def _create_team(session: AsyncSession, name: str) -> TeamDB:
+    """Create and flush a team record."""
+    team = TeamDB(name=name)
+    session.add(team)
+    await session.flush()
+    return team
+
+
+async def _create_asset(session: AsyncSession, team: TeamDB, fqn: str) -> AssetDB:
+    """Create and flush an asset record."""
+    asset = AssetDB(fqn=fqn, owner_team_id=team.id)
+    session.add(asset)
+    await session.flush()
+    return asset
+
+
+async def _create_contract(
+    session: AsyncSession, asset: AssetDB, team: TeamDB, version: str = "1.0.0"
+) -> ContractDB:
+    """Create and flush a contract record."""
+    contract = ContractDB(
+        asset_id=asset.id,
+        version=version,
+        schema_def={"type": "object"},
+        compatibility_mode=CompatibilityMode.BACKWARD,
+        status=ContractStatus.ACTIVE,
+        published_by=team.id,
+    )
+    session.add(contract)
+    await session.flush()
+    return contract
+
+
+@pytest.mark.asyncio
+class TestUpdatedAtAutoPopulate:
+    """Verify updated_at is set on ORM-level updates."""
+
+    async def test_updated_at_null_on_insert(self, test_session: AsyncSession) -> None:
+        """updated_at should be None when a row is first created."""
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        assert team.updated_at is None
+
+    async def test_updated_at_set_on_update(self, test_session: AsyncSession) -> None:
+        """updated_at should be populated after an ORM update."""
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        assert team.updated_at is None
+
+        team.name = f"renamed-{uuid4().hex[:8]}"
+        await test_session.flush()
+        # After flush, SQLAlchemy runs the onupdate callable
+        assert team.updated_at is not None
+        assert isinstance(team.updated_at, datetime)
+
+    async def test_updated_at_on_asset(self, test_session: AsyncSession) -> None:
+        """updated_at should work on AssetDB."""
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        asset = await _create_asset(test_session, team, f"db.schema.tbl_{uuid4().hex[:8]}")
+        assert asset.updated_at is None
+
+        asset.metadata_ = {"changed": True}
+        await test_session.flush()
+        assert asset.updated_at is not None
+
+    async def test_updated_at_on_contract(self, test_session: AsyncSession) -> None:
+        """updated_at should work on ContractDB."""
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        asset = await _create_asset(test_session, team, f"db.schema.c_{uuid4().hex[:8]}")
+        contract = await _create_contract(test_session, asset, team)
+        assert contract.updated_at is None
+
+        contract.status = ContractStatus.DEPRECATED
+        await test_session.flush()
+        assert contract.updated_at is not None
+
+    async def test_updated_at_on_registration(self, test_session: AsyncSession) -> None:
+        """updated_at should work on RegistrationDB."""
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        consumer = await _create_team(test_session, f"consumer-{uuid4().hex[:8]}")
+        asset = await _create_asset(test_session, team, f"db.schema.r_{uuid4().hex[:8]}")
+        contract = await _create_contract(test_session, asset, team)
+
+        reg = RegistrationDB(contract_id=contract.id, consumer_team_id=consumer.id)
+        test_session.add(reg)
+        await test_session.flush()
+        assert reg.updated_at is None
+
+        reg.pinned_version = "1.0.0"
+        await test_session.flush()
+        assert reg.updated_at is not None
+
+
+@pytest.mark.asyncio
+class TestSoftDeleteReCreation:
+    """Verify that soft-deleted rows don't block re-creation.
+
+    SQLite uses global unique constraints (no partial index support),
+    so these tests validate that the model-level constraints still work
+    correctly. On PostgreSQL (with partial indexes from migration 014),
+    soft-deleted rows would be excluded from uniqueness checks.
+    """
+
+    async def test_asset_fqn_unique_among_live_rows(self, test_session: AsyncSession) -> None:
+        """Two live assets with the same fqn+environment should fail."""
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        fqn = f"db.schema.dup_{uuid4().hex[:8]}"
+
+        asset1 = AssetDB(fqn=fqn, owner_team_id=team.id, environment="production")
+        test_session.add(asset1)
+        await test_session.flush()
+
+        asset2 = AssetDB(fqn=fqn, owner_team_id=team.id, environment="production")
+        test_session.add(asset2)
+        with pytest.raises(Exception):  # IntegrityError
+            await test_session.flush()
+        await test_session.rollback()
+
+    async def test_team_name_unique_among_live_rows(self, test_session: AsyncSession) -> None:
+        """Two live teams with the same name should fail."""
+        name = f"unique-team-{uuid4().hex[:8]}"
+
+        team1 = TeamDB(name=name)
+        test_session.add(team1)
+        await test_session.flush()
+
+        team2 = TeamDB(name=name)
+        test_session.add(team2)
+        with pytest.raises(Exception):  # IntegrityError
+            await test_session.flush()
+        await test_session.rollback()
+
+
+@pytest.mark.asyncio
+class TestAuditTimeRangeQuery:
+    """Verify audit_events indexes support time-range queries."""
+
+    async def test_time_range_filter(self, test_session: AsyncSession) -> None:
+        """Filtering audit_events by occurred_at should work correctly."""
+        t1 = datetime(2025, 1, 1, tzinfo=UTC)
+        t2 = datetime(2025, 6, 1, tzinfo=UTC)
+        t3 = datetime(2025, 12, 1, tzinfo=UTC)
+
+        for ts in [t1, t2, t3]:
+            event = AuditEventDB(
+                entity_type="team",
+                entity_id=uuid4(),
+                action="created",
+                occurred_at=ts,
+            )
+            test_session.add(event)
+        await test_session.flush()
+
+        # Query range: Jan–June 2025
+        start = datetime(2025, 1, 1, tzinfo=UTC)
+        end = datetime(2025, 7, 1, tzinfo=UTC)
+
+        stmt = (
+            select(AuditEventDB)
+            .where(AuditEventDB.occurred_at >= start)
+            .where(AuditEventDB.occurred_at < end)
+        )
+        result = await test_session.execute(stmt)
+        events = result.scalars().all()
+        assert len(events) == 2
+
+    async def test_entity_type_time_range_filter(self, test_session: AsyncSession) -> None:
+        """Composite (entity_type, occurred_at) filter should work correctly."""
+        ts = datetime(2025, 6, 15, tzinfo=UTC)
+
+        for entity_type in ["team", "asset", "team"]:
+            event = AuditEventDB(
+                entity_type=entity_type,
+                entity_id=uuid4(),
+                action="updated",
+                occurred_at=ts,
+            )
+            test_session.add(event)
+        await test_session.flush()
+
+        stmt = (
+            select(AuditEventDB)
+            .where(AuditEventDB.entity_type == "team")
+            .where(AuditEventDB.occurred_at >= datetime(2025, 1, 1, tzinfo=UTC))
+        )
+        result = await test_session.execute(stmt)
+        events = result.scalars().all()
+        assert len(events) == 2
+
+    async def test_actor_id_filter(self, test_session: AsyncSession) -> None:
+        """Filtering by actor_id should work correctly."""
+        actor = uuid4()
+        other_actor = uuid4()
+
+        for aid in [actor, actor, other_actor]:
+            event = AuditEventDB(
+                entity_type="contract",
+                entity_id=uuid4(),
+                action="published",
+                actor_id=aid,
+            )
+            test_session.add(event)
+        await test_session.flush()
+
+        stmt = select(AuditEventDB).where(AuditEventDB.actor_id == actor)
+        result = await test_session.execute(stmt)
+        events = result.scalars().all()
+        assert len(events) == 2
+
+
+@pytest.mark.asyncio
+class TestForeignKeyConstraints:
+    """Verify FK constraints on published_by and proposed_by."""
+
+    async def test_contract_published_by_references_valid_team(
+        self, test_session: AsyncSession
+    ) -> None:
+        """Creating a contract with a valid team ID for published_by should succeed."""
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        asset = await _create_asset(test_session, team, f"db.schema.fk_{uuid4().hex[:8]}")
+        contract = await _create_contract(test_session, asset, team)
+        assert contract.published_by == team.id
+
+    async def test_contract_published_by_fk_enforced(self, test_session: AsyncSession) -> None:
+        """Check that the FK column exists and references a real team.
+
+        On SQLite the FK is enforced at create_all time via the model
+        definition. On PostgreSQL the migration adds the constraint.
+        We verify the column value matches an existing team.
+        """
+        team = await _create_team(test_session, f"team-{uuid4().hex[:8]}")
+        asset = await _create_asset(test_session, team, f"db.schema.fk2_{uuid4().hex[:8]}")
+        contract = await _create_contract(test_session, asset, team)
+
+        # Verify the published_by value resolves to a team
+        stmt = select(TeamDB).where(TeamDB.id == contract.published_by)
+        result = await test_session.execute(stmt)
+        referenced_team = result.scalar_one_or_none()
+        assert referenced_team is not None
+        assert referenced_team.id == team.id


### PR DESCRIPTION
## Summary

- Add `updated_at` column (nullable, `onupdate=_utcnow`) to 7 mutable models (`AssetDB`, `TeamDB`, `UserDB`, `ContractDB`, `RegistrationDB`, `ProposalDB`, `APIKeyDB`) to support incremental sync and optimistic concurrency
- Add B-tree indexes on `audit_events` (`occurred_at`, `actor_id`, composite `entity_type+occurred_at`) to eliminate O(n) time-range scans
- Add FK constraints on `contracts.published_by` and `proposals.proposed_by` → `teams.id` (PostgreSQL only)
- Fix `TIMESTAMP` → `TIMESTAMPTZ` on all DateTime columns from migration 001 (PostgreSQL only)
- Convert 4 global unique constraints to partial unique indexes (`WHERE deleted_at IS NULL`) so soft-deleted rows no longer block re-creation (PostgreSQL only)

## Test plan

- [x] 12 new tests in `test_schema_hardening.py` covering `updated_at` auto-populate, soft-delete uniqueness, audit time-range queries, and FK integrity
- [x] Full suite (994 tests) passes on SQLite
- [x] ruff, ruff-format, mypy all clean
- [ ] Verify migrations run on PostgreSQL (TIMESTAMPTZ fix, FK constraints, partial unique indexes)