### PR TITLE
fix: concurrency safety for 4 race conditions

### DIFF
--- a/src/tessera/api/bulk.py
+++ b/src/tessera/api/bulk.py
@@ -385,9 +385,11 @@ async def bulk_acknowledge_proposals(
                     code=ErrorCode.FORBIDDEN,
                 )
 
-            # Verify proposal exists
+            # Verify proposal exists — lock the row to prevent concurrent
+            # acks from both triggering auto-approval (matches single-ack
+            # pattern in proposals.py).
             proposal_result = await session.execute(
-                select(ProposalDB).where(ProposalDB.id == item.proposal_id)
+                select(ProposalDB).where(ProposalDB.id == item.proposal_id).with_for_update()
             )
             proposal = proposal_result.scalar_one_or_none()
             if not proposal:


### PR DESCRIPTION
## Summary

- **Bulk ack**: Add `with_for_update()` on proposal query to prevent double auto-approval when concurrent acks both trigger completion check
- **publish_from_proposal**: Lock proposal row and active contract to prevent double-publish; handle `IntegrityError` on duplicate version with proper 409 response
- **Objection filing**: Split join query to lock proposal row before read-modify-write of JSON objections array (prevents lost updates)
- **Webhook failure isolation**: Wrap `send_contract_published` in try/except so webhook scheduling failure doesn't cause 500 on a committed publish

## Test plan

- [x] `test_double_publish_from_proposal_second_rejected` — second publish on same approved proposal returns 409
- [x] `test_two_objections_both_preserved` — both objections from different teams appear in proposal
- [x] `test_duplicate_objection_from_same_team_rejected` — same team can't object twice
- [x] `test_bulk_ack_duplicate_proposal_in_batch` — duplicate ack in batch fails correctly
- [x] `test_bulk_ack_all_consumers_triggers_approval` — bulk ack auto-approves when all consumers ack
- [x] All 999 existing tests pass