### PR TITLE
fix: close durability gaps from code review

### DIFF
--- a/alembic/versions/015_add_proposal_published_status.py
+++ b/alembic/versions/015_add_proposal_published_status.py
@@ -1,0 +1,50 @@
+"""Add enum values for ProposalStatus and WebhookDeliveryStatus.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-02-16
+
+Adds:
+- ProposalStatus.PUBLISHED: terminal state after a proposal is published
+  as a contract, so it cannot be published again and resolved_at is set.
+- WebhookDeliveryStatus.DEAD_LETTERED: status for events queued in the
+  dead letter queue when the circuit breaker is open.
+
+PostgreSQL only — SQLite uses VARCHAR for enums so no migration is needed.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "015"
+down_revision: str = "014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _is_sqlite() -> bool:
+    """Check if we're running against SQLite."""
+    bind = op.get_bind()
+    return bind.dialect.name == "sqlite"
+
+
+def upgrade() -> None:
+    """Add new enum values."""
+    if _is_sqlite():
+        # SQLite stores enums as VARCHAR — no schema change needed.
+        return
+
+    op.execute("ALTER TYPE proposalstatus ADD VALUE IF NOT EXISTS 'published' AFTER 'approved'")
+    op.execute(
+        "ALTER TYPE webhookdeliverystatus ADD VALUE IF NOT EXISTS 'dead_lettered' AFTER 'failed'"
+    )
+
+
+def downgrade() -> None:
+    """PostgreSQL does not support removing enum values.
+
+    The new values will remain in the types but be unused after downgrade.
+    """
+    pass

--- a/src/tessera/models/enums.py
+++ b/src/tessera/models/enums.py
@@ -41,6 +41,7 @@ class ProposalStatus(StrEnum):
 
     PENDING = "pending"
     APPROVED = "approved"
+    PUBLISHED = "published"
     REJECTED = "rejected"
     WITHDRAWN = "withdrawn"
     EXPIRED = "expired"
@@ -76,6 +77,7 @@ class WebhookDeliveryStatus(StrEnum):
     PENDING = "pending"  # Queued for delivery
     DELIVERED = "delivered"  # Successfully delivered (2xx response)
     FAILED = "failed"  # Failed after all retries
+    DEAD_LETTERED = "dead_lettered"  # Circuit breaker open; queued for replay
 
 
 class GuaranteeMode(StrEnum):

--- a/src/tessera/services/__init__.py
+++ b/src/tessera/services/__init__.py
@@ -11,6 +11,7 @@ from tessera.services.audit import (
     log_proposal_approved,
     log_proposal_created,
     log_proposal_force_approved,
+    log_proposal_published,
     log_proposal_rejected,
 )
 from tessera.services.batch import (
@@ -94,6 +95,7 @@ __all__ = [
     "log_proposal_acknowledged",
     "log_proposal_approved",
     "log_proposal_force_approved",
+    "log_proposal_published",
     "log_proposal_rejected",
     # OpenAPI parsing
     "AssetFromOpenAPI",

--- a/src/tessera/services/audit.py
+++ b/src/tessera/services/audit.py
@@ -52,6 +52,7 @@ class AuditAction(StrEnum):
     PROPOSAL_APPROVED = "proposal.approved"
     PROPOSAL_REJECTED = "proposal.rejected"
     PROPOSAL_EXPIRED = "proposal.expired"
+    PROPOSAL_PUBLISHED = "proposal.published"
 
     # Restore actions
     ASSET_RESTORED = "asset.restored"
@@ -237,6 +238,27 @@ async def log_proposal_approved(
         entity_id=proposal_id,
         action=AuditAction.PROPOSAL_APPROVED,
         payload={"acknowledged_count": acknowledged_count, "auto_approved": True},
+    )
+
+
+async def log_proposal_published(
+    session: AsyncSession,
+    proposal_id: UUID,
+    contract_id: UUID,
+    publisher_id: UUID,
+    version: str,
+) -> AuditEventDB:
+    """Log that an approved proposal was published as a contract."""
+    return await log_event(
+        session=session,
+        entity_type="proposal",
+        entity_id=proposal_id,
+        action=AuditAction.PROPOSAL_PUBLISHED,
+        actor_id=publisher_id,
+        payload={
+            "contract_id": str(contract_id),
+            "version": version,
+        },
     )
 
 


### PR DESCRIPTION
## Summary

Fixes 4 durability/paper-trail issues identified during comprehensive code review:

- **#333** `publish_from_proposal` now sets proposal to `PUBLISHED` terminal state with `resolved_at` timestamp and `PROPOSAL_PUBLISHED` audit event. Second publish attempt returns 400 "already published" instead of hitting the IntegrityError fallback.
- **#335** `expire_proposal` and `expire_pending_proposals` now use `with_for_update(skip_locked=True)` to prevent overlapping cron runs from creating duplicate `proposal.expired` audit events.
- **#336** Dead-lettered webhook events use `DEAD_LETTERED` status (not `FAILED`) for clarity. Module docstring documents that the dead letter queue is in-memory and lost on restart.
- **#337** `invalidate_asset()` docstring documents the timing semantics of cache invalidation outside transaction boundaries (self-healing via TTL).

Also closed **#334** (bulk_publish partial commit) as not-a-bug — the existing `except Exception` catch-all already prevents unhandled exceptions from escaping the loop.

## Changes

| File | Change |
|------|--------|
| `models/enums.py` | Add `ProposalStatus.PUBLISHED`, `WebhookDeliveryStatus.DEAD_LETTERED` |
| `services/audit.py` | Add `PROPOSAL_PUBLISHED` action + `log_proposal_published()` |
| `services/__init__.py` | Export `log_proposal_published` |
| `api/proposals.py` | Set terminal status after publish, clear error for re-publish |
| `services/expiration.py` | Add `with_for_update(skip_locked=True)` to both expire functions |
| `services/webhooks.py` | Use `DEAD_LETTERED` status, document in-memory limitations |
| `services/cache.py` | Document invalidation timing semantics |
| `alembic/versions/015_...py` | Migration: add new enum values for PostgreSQL |
| `tests/test_concurrent_operations.py` | 4 new tests (18 total in file, 1001 total suite) |

## Test plan

- [x] `test_double_publish_from_proposal_second_rejected` — verifies proposal transitions to `published` and second attempt gets 400
- [x] `test_double_expire_second_fails` — verifies second expiration returns 400
- [x] `test_expire_already_published_proposal_fails` — verifies published proposal cannot be expired
- [x] Full suite: 1001 tests pass
- [x] ruff, ruff-format, mypy all clean

Closes #333, closes #335, closes #336, closes #337