### PR TITLE
fix: auth logging and Redis timeout config

### DIFF
--- a/src/tessera/api/auth.py
+++ b/src/tessera/api/auth.py
@@ -295,7 +295,8 @@ async def get_optional_auth_context(
 
     try:
         return await get_auth_context(request, authorization, session)
-    except HTTPException:
+    except HTTPException as e:
+        logger.debug("Optional auth failed (status=%s): %s", e.status_code, e.detail)
         return None
 
 

--- a/src/tessera/config.py
+++ b/src/tessera/config.py
@@ -72,6 +72,8 @@ class Settings(BaseSettings):  # type: ignore[misc]
 
     # Redis cache (optional)
     redis_url: str | None = None  # e.g., redis://localhost:6379/0
+    redis_connect_timeout: float = 0.05  # Connect timeout in seconds
+    redis_socket_timeout: float = 0.05  # Operation timeout in seconds
     cache_ttl: int = 300  # Default cache TTL in seconds (5 minutes)
     cache_ttl_contract: int = 600  # 10 minutes
     cache_ttl_asset: int = 300  # 5 minutes

--- a/src/tessera/services/cache.py
+++ b/src/tessera/services/cache.py
@@ -41,12 +41,12 @@ async def get_redis_client() -> "redis.Redis[Any] | None":
             settings.redis_url,
             decode_responses=False,
             max_connections=10,
-            socket_connect_timeout=0.05,  # 50ms timeout for fast failure in tests
-            socket_timeout=0.05,  # 50ms timeout for operations
+            socket_connect_timeout=settings.redis_connect_timeout,
+            socket_timeout=settings.redis_socket_timeout,
         )
         _redis_client = redis.Redis(connection_pool=_redis_pool)
-        # Test connection with very short timeout
-        await asyncio.wait_for(_redis_client.ping(), timeout=0.05)
+        # Test connection with connect timeout
+        await asyncio.wait_for(_redis_client.ping(), timeout=settings.redis_connect_timeout)
         logger.info("Connected to Redis cache")
         return _redis_client
     except (TimeoutError, Exception) as e:


### PR DESCRIPTION
## Summary
- **#222**: Add `logger.debug()` to the silent `except HTTPException` in `get_optional_auth_context` so failed optional auth attempts are traceable in production logs
- **#259**: Extract hardcoded Redis timeout values (`0.05s`) to configurable settings (`REDIS_CONNECT_TIMEOUT`, `REDIS_SOCKET_TIMEOUT`) so operators can tune them per environment
- **#262**: Closed — `HASH_KEY_LENGTH` constant already exists in both `cache.py` and `rate_limit.py`
- **#269**: Closed — `_db_to_api_key()` helper already exists in `services/auth.py`

## Test plan
- [x] 999 tests pass
- [x] ruff, ruff-format, mypy all clean
- [x] Default values unchanged (0.05s) so no behavioral change without explicit config

Closes #222, closes #259