### PR TITLE
fix: recursive schema property count and nesting depth validation

### DIFF
--- a/src/tessera/config.py
+++ b/src/tessera/config.py
@@ -236,7 +236,12 @@ class Settings(BaseSettings):  # type: ignore[misc]
     )
     max_schema_properties: int = Field(
         default=1000,
-        description="Maximum number of top-level properties in a schema.",
+        description="Maximum total properties across all nesting levels in a schema.",
+    )
+    max_schema_nesting_depth: int = Field(
+        default=10,
+        description="Maximum nesting depth for schema objects. "
+        "Prevents DoS from deeply recursive schema definitions.",
     )
     max_fqn_length: int = Field(
         default=1000,

--- a/src/tessera/models/contract.py
+++ b/src/tessera/models/contract.py
@@ -32,6 +32,47 @@ class Guarantees(BaseModel):
     )
 
 
+def _count_all_properties(schema: dict[str, Any]) -> int:
+    """Count total properties across all nesting levels.
+
+    Counts properties within objects (and within array items) recursively
+    so that deeply nested schemas with many leaf properties are correctly
+    measured against ``settings.max_schema_properties``.
+    """
+    count = 0
+    if isinstance(schema, dict):
+        if schema.get("type") == "object" and "properties" in schema:
+            props: dict[str, Any] = schema["properties"]
+            count += len(props)
+            for prop_schema in props.values():
+                count += _count_all_properties(prop_schema)
+        if "items" in schema:
+            count += _count_all_properties(schema["items"])
+    return count
+
+
+def _max_nesting_depth(schema: dict[str, Any], current: int = 0) -> int:
+    """Return the maximum object-nesting depth in *schema*.
+
+    Only object types with ``properties`` advance the depth counter, so
+    arrays and scalar sub-schemas don't inflate the count.
+    """
+    if not isinstance(schema, dict):
+        return current
+    if schema.get("type") == "object" and "properties" in schema:
+        child_depth = current + 1
+        return max(
+            (
+                _max_nesting_depth(prop_schema, child_depth)
+                for prop_schema in schema["properties"].values()
+            ),
+            default=child_depth,
+        )
+    if "items" in schema:
+        return _max_nesting_depth(schema["items"], current)
+    return current
+
+
 class ContractBase(BaseModel):
     """Base contract fields."""
 
@@ -64,14 +105,22 @@ class ContractBase(BaseModel):
                 f"Current size: {len(serialized):,} bytes."
             )
 
-        # 2. Check property count (if object)
-        if v.get("type") == "object" and "properties" in v:
-            props_count = len(v["properties"])
-            if props_count > settings.max_schema_properties:
-                raise ValueError(
-                    f"Too many properties in schema. Maximum: {settings.max_schema_properties}. "
-                    f"Found: {props_count}."
-                )
+        # 2. Check total property count across all nesting levels
+        total_props = _count_all_properties(v)
+        if total_props > settings.max_schema_properties:
+            raise ValueError(
+                f"Too many properties in schema (including nested). "
+                f"Maximum: {settings.max_schema_properties}. Found: {total_props}."
+            )
+
+        # 3. Check nesting depth
+        depth = _max_nesting_depth(v)
+        if depth > settings.max_schema_nesting_depth:
+            raise ValueError(
+                f"Schema nesting too deep. "
+                f"Maximum depth: {settings.max_schema_nesting_depth}. Found: {depth}."
+            )
+
         return v
 
 

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,5 +1,7 @@
 """Tests for input validation."""
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -252,8 +254,7 @@ class TestSchemaSizeValidation:
         assert "too large" in str(exc_info.value).lower()
 
     def test_invalid_schema_too_many_properties(self) -> None:
-        """Invalid schema with too many properties."""
-        # Create a schema with more than settings.max_schema_properties
+        """Invalid schema with too many properties at top level."""
         too_many_props = {
             f"field_{i}": {"type": "string"} for i in range(settings.max_schema_properties + 1)
         }
@@ -263,6 +264,72 @@ class TestSchemaSizeValidation:
                 version="1.0.0",
                 schema={"type": "object", "properties": too_many_props},
             )
+        assert "too many properties" in str(exc_info.value).lower()
+
+    def test_invalid_schema_too_many_nested_properties(self) -> None:
+        """Deeply nested schema that exceeds total property limit must be rejected."""
+        # One top-level property containing a nested object with enough children to
+        # push the total count over the limit.
+        nested_props = {
+            f"nested_{i}": {"type": "string"} for i in range(settings.max_schema_properties + 1)
+        }
+        schema = {
+            "type": "object",
+            "properties": {
+                "level1": {
+                    "type": "object",
+                    "properties": nested_props,
+                }
+            },
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            ContractCreate(version="1.0.0", schema=schema)
+        assert "too many properties" in str(exc_info.value).lower()
+
+    def test_valid_schema_nested_within_limit(self) -> None:
+        """Nested schema within both property and depth limits is accepted."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        }
+                    },
+                }
+            },
+        }
+        contract = ContractCreate(version="1.0.0", schema=schema)
+        assert contract.schema_def == schema
+
+    def test_invalid_schema_nesting_too_deep(self) -> None:
+        """Schema nested beyond max depth must be rejected."""
+        # Build a schema nested one level deeper than the limit.
+        schema: dict[str, Any] = {"type": "string"}
+        for _ in range(settings.max_schema_nesting_depth + 1):
+            schema = {"type": "object", "properties": {"child": schema}}
+
+        with pytest.raises(ValidationError) as exc_info:
+            ContractCreate(version="1.0.0", schema=schema)
+        assert "nesting too deep" in str(exc_info.value).lower()
+
+    def test_valid_schema_array_items_counted(self) -> None:
+        """Properties inside array items are counted toward the total."""
+        # Array item with enough leaf properties to exceed the limit.
+        item_props = {
+            f"col_{i}": {"type": "string"} for i in range(settings.max_schema_properties + 1)
+        }
+        schema = {
+            "type": "array",
+            "items": {"type": "object", "properties": item_props},
+        }
+
+        with pytest.raises(ValidationError) as exc_info:
+            ContractCreate(version="1.0.0", schema=schema)
         assert "too many properties" in str(exc_info.value).lower()
 
 


### PR DESCRIPTION
## Summary

Closes #235.

- `_count_all_properties`: replaces top-level-only property count with recursive traversal of nested objects and array `items`
- `_max_nesting_depth`: new check enforcing a max object nesting depth (default 10)
- `max_schema_nesting_depth` added to config (default 10)

Without this fix, a schema with 1 top-level property containing 10,000 nested properties would pass validation.

## Test plan
- `test_invalid_schema_too_many_nested_properties` — nested overflow rejected
- `test_valid_schema_nested_within_limit` — valid nested schema accepted
- `test_invalid_schema_nesting_too_deep` — depth overflow rejected
- `test_valid_schema_array_items_counted` — array item properties counted