### PR TITLE
docs: add OpenAPI error response documentation to all endpoints

### DIFF
--- a/src/tessera/api/assets.py
+++ b/src/tessera/api/assets.py
@@ -98,6 +98,17 @@ from tessera.services.versioning import (
 
 router = APIRouter()
 
+# Standard error response descriptions shared across endpoints.
+_E: dict[int, dict[str, str]] = {
+    400: {"description": "Bad request — invalid input or parameters"},
+    401: {"description": "Authentication required"},
+    403: {"description": "Forbidden — insufficient permissions or wrong team"},
+    404: {"description": "Resource not found"},
+    409: {"description": "Conflict — duplicate resource"},
+    412: {"description": "Precondition failed — passing audit run required"},
+    422: {"description": "Validation error — invalid request body"},
+}
+
 
 def _apply_asset_search_filters(
     query: Select[Any],
@@ -171,7 +182,12 @@ async def _get_team_name(session: AsyncSession, team_id: UUID) -> str:
     return name if name else "unknown"
 
 
-@router.post("", response_model=Asset, status_code=201)
+@router.post(
+    "",
+    response_model=Asset,
+    status_code=201,
+    responses={k: _E[k] for k in (400, 401, 403, 404, 409)},
+)
 @limit_write
 async def create_asset(
     request: Request,
@@ -261,7 +277,7 @@ async def create_asset(
     return db_asset
 
 
-@router.get("")
+@router.get("", responses={k: _E[k] for k in (401, 403)})
 @limit_read
 async def list_assets(
     request: Request,
@@ -382,7 +398,7 @@ async def list_assets(
     }
 
 
-@router.get("/search")
+@router.get("/search", responses={k: _E[k] for k in (401, 403)})
 @limit_read
 async def search_assets(
     request: Request,
@@ -463,7 +479,7 @@ async def search_assets(
     return response
 
 
-@router.get("/{asset_id}")
+@router.get("/{asset_id}", responses={k: _E[k] for k in (401, 403, 404)})
 @limit_read
 async def get_asset(
     request: Request,
@@ -510,7 +526,11 @@ async def get_asset(
     return asset_dict
 
 
-@router.patch("/{asset_id}", response_model=Asset)
+@router.patch(
+    "/{asset_id}",
+    response_model=Asset,
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
 @limit_write
 async def update_asset(
     request: Request,
@@ -600,7 +620,11 @@ async def update_asset(
     return asset
 
 
-@router.delete("/{asset_id}", status_code=204)
+@router.delete(
+    "/{asset_id}",
+    status_code=204,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_write
 async def delete_asset(
     request: Request,
@@ -648,7 +672,11 @@ async def delete_asset(
     await asset_cache.delete(str(asset_id))
 
 
-@router.post("/{asset_id}/restore", response_model=Asset)
+@router.post(
+    "/{asset_id}/restore",
+    response_model=Asset,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_write
 async def restore_asset(
     request: Request,
@@ -754,7 +782,12 @@ def _build_publish_response(
     return response
 
 
-@router.post("/{asset_id}/contracts", status_code=201, response_model=None)
+@router.post(
+    "/{asset_id}/contracts",
+    status_code=201,
+    response_model=None,
+    responses={k: _E[k] for k in (400, 401, 403, 404, 409, 412)},
+)
 @limit_write
 async def create_contract(
     request: Request,
@@ -1006,7 +1039,7 @@ async def create_contract(
     return _build_publish_response(result, original_format)
 
 
-@router.get("/{asset_id}/contracts")
+@router.get("/{asset_id}/contracts", responses={k: _E[k] for k in (401, 403)})
 @limit_read
 async def list_asset_contracts(
     request: Request,
@@ -1072,7 +1105,10 @@ async def list_asset_contracts(
     return response
 
 
-@router.get("/{asset_id}/contracts/history")
+@router.get(
+    "/{asset_id}/contracts/history",
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_read
 async def get_contract_history(
     request: Request,
@@ -1133,7 +1169,10 @@ async def get_contract_history(
     )
 
 
-@router.get("/{asset_id}/contracts/diff")
+@router.get(
+    "/{asset_id}/contracts/diff",
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
 @limit_read
 @limit_expensive  # Per-team rate limit for expensive schema diff operation
 async def diff_contract_versions(
@@ -1214,7 +1253,11 @@ async def diff_contract_versions(
     )
 
 
-@router.post("/{asset_id}/version-suggestion", response_model=VersionSuggestion)
+@router.post(
+    "/{asset_id}/version-suggestion",
+    response_model=VersionSuggestion,
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
 @limit_read
 async def preview_version_suggestion(
     request: Request,
@@ -1307,7 +1350,7 @@ async def preview_version_suggestion(
         return compute_version_suggestion(None, ChangeType.PATCH, True)
 
 
-@router.post("/bulk-assign")
+@router.post("/bulk-assign", responses={k: _E[k] for k in (401, 403, 404)})
 @limit_write
 async def bulk_assign_owner(
     request: Request,

--- a/src/tessera/api/proposals.py
+++ b/src/tessera/api/proposals.py
@@ -66,6 +66,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+_E: dict[int, dict[str, str]] = {
+    400: {"description": "Bad request — invalid input or parameters"},
+    401: {"description": "Authentication required"},
+    403: {"description": "Forbidden — insufficient permissions or wrong team"},
+    404: {"description": "Resource not found"},
+    409: {"description": "Conflict — duplicate resource"},
+    412: {"description": "Precondition failed — passing audit run required"},
+    422: {"description": "Validation error — invalid request body"},
+}
+
 
 async def _get_asset_audit_info(session: AsyncSession, asset_id: UUID) -> dict[str, Any] | None:
     """Get the most recent audit run info for an asset.
@@ -151,7 +161,7 @@ async def check_proposal_completion(
     return all_acknowledged, len(acknowledgments)
 
 
-@router.get("")
+@router.get("", responses={k: _E[k] for k in (401, 403)})
 @limit_read
 async def list_proposals(
     request: Request,
@@ -340,7 +350,11 @@ async def list_proposals(
     }
 
 
-@router.get("/{proposal_id}", response_model=Proposal)
+@router.get(
+    "/{proposal_id}",
+    response_model=Proposal,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_read
 async def get_proposal(
     request: Request,
@@ -360,7 +374,7 @@ async def get_proposal(
     return proposal
 
 
-@router.get("/{proposal_id}/status")
+@router.get("/{proposal_id}/status", responses={k: _E[k] for k in (401, 403, 404)})
 @limit_read
 async def get_proposal_status(
     request: Request,
@@ -520,7 +534,12 @@ async def get_proposal_status(
     }
 
 
-@router.post("/{proposal_id}/acknowledge", response_model=Acknowledgment, status_code=201)
+@router.post(
+    "/{proposal_id}/acknowledge",
+    response_model=Acknowledgment,
+    status_code=201,
+    responses={k: _E[k] for k in (400, 401, 403, 404, 409)},
+)
 @limit_write
 async def acknowledge_proposal(
     request: Request,
@@ -719,7 +738,11 @@ async def acknowledge_proposal(
     return db_ack
 
 
-@router.post("/{proposal_id}/withdraw", response_model=Proposal)
+@router.post(
+    "/{proposal_id}/withdraw",
+    response_model=Proposal,
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
 @limit_write
 async def withdraw_proposal(
     request: Request,
@@ -781,7 +804,11 @@ async def withdraw_proposal(
     return proposal
 
 
-@router.post("/{proposal_id}/object", status_code=201)
+@router.post(
+    "/{proposal_id}/object",
+    status_code=201,
+    responses={k: _E[k] for k in (400, 401, 403, 404, 409)},
+)
 @limit_write
 async def file_objection(
     request: Request,
@@ -905,7 +932,11 @@ async def file_objection(
     }
 
 
-@router.post("/{proposal_id}/force", response_model=Proposal)
+@router.post(
+    "/{proposal_id}/force",
+    response_model=Proposal,
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
 @limit_admin
 async def force_proposal(
     request: Request,
@@ -973,7 +1004,10 @@ async def force_proposal(
     return proposal
 
 
-@router.post("/{proposal_id}/publish")
+@router.post(
+    "/{proposal_id}/publish",
+    responses={k: _E[k] for k in (400, 401, 403, 404, 409)},
+)
 @limit_write
 async def publish_from_proposal(
     request: Request,
@@ -1147,7 +1181,11 @@ async def publish_from_proposal(
     return response
 
 
-@router.post("/{proposal_id}/expire", response_model=Proposal)
+@router.post(
+    "/{proposal_id}/expire",
+    response_model=Proposal,
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
 @limit_write
 async def expire_proposal(
     request: Request,
@@ -1199,7 +1237,7 @@ async def expire_proposal(
     return expired
 
 
-@router.post("/expire-pending")
+@router.post("/expire-pending", responses={k: _E[k] for k in (401, 403)})
 @limit_write
 async def expire_pending_proposals(
     request: Request,

--- a/src/tessera/api/teams.py
+++ b/src/tessera/api/teams.py
@@ -41,8 +41,22 @@ class TeamWithAssetCount(TypedDict, total=False):
 
 router = APIRouter()
 
+_E: dict[int, dict[str, str]] = {
+    400: {"description": "Bad request — invalid input or parameters"},
+    401: {"description": "Authentication required"},
+    403: {"description": "Forbidden — insufficient permissions or wrong team"},
+    404: {"description": "Resource not found"},
+    409: {"description": "Conflict — duplicate resource or team has active assets"},
+    422: {"description": "Validation error — invalid request body"},
+}
 
-@router.post("", response_model=Team, status_code=201)
+
+@router.post(
+    "",
+    response_model=Team,
+    status_code=201,
+    responses={k: _E[k] for k in (401, 403, 409)},
+)
 @limit_write
 async def create_team(
     request: Request,
@@ -79,7 +93,7 @@ async def create_team(
     return db_team
 
 
-@router.get("")
+@router.get("", responses={k: _E[k] for k in (401, 403)})
 @limit_read
 async def list_teams(
     request: Request,
@@ -126,7 +140,11 @@ async def list_teams(
     }
 
 
-@router.get("/{team_id}", response_model=Team)
+@router.get(
+    "/{team_id}",
+    response_model=Team,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_read
 async def get_team(
     request: Request,
@@ -148,8 +166,16 @@ async def get_team(
     return team
 
 
-@router.patch("/{team_id}", response_model=Team)
-@router.put("/{team_id}", response_model=Team)
+@router.patch(
+    "/{team_id}",
+    response_model=Team,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
+@router.put(
+    "/{team_id}",
+    response_model=Team,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_write
 async def update_team(
     request: Request,
@@ -195,7 +221,11 @@ async def update_team(
     return team
 
 
-@router.delete("/{team_id}", status_code=204)
+@router.delete(
+    "/{team_id}",
+    status_code=204,
+    responses={k: _E[k] for k in (401, 403, 404, 409)},
+)
 @limit_write
 async def delete_team(
     request: Request,
@@ -248,7 +278,11 @@ async def delete_team(
     await team_cache.delete(str(team_id))
 
 
-@router.post("/{team_id}/restore", response_model=Team)
+@router.post(
+    "/{team_id}/restore",
+    response_model=Team,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_write
 async def restore_team(
     request: Request,
@@ -289,7 +323,7 @@ async def restore_team(
     return team
 
 
-@router.get("/{team_id}/members")
+@router.get("/{team_id}/members", responses={k: _E[k] for k in (401, 403, 404)})
 @limit_read
 async def list_team_members(
     request: Request,
@@ -343,7 +377,10 @@ class ReassignAssetsRequest(BaseModel):
     asset_ids: list[UUID] | None = None  # If None, reassign all assets
 
 
-@router.post("/{team_id}/reassign-assets")
+@router.post(
+    "/{team_id}/reassign-assets",
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
 @limit_write
 async def reassign_team_assets(
     request: Request,

--- a/src/tessera/api/users.py
+++ b/src/tessera/api/users.py
@@ -41,8 +41,22 @@ _hasher = PasswordHasher()
 
 router = APIRouter()
 
+_E: dict[int, dict[str, str]] = {
+    400: {"description": "Bad request — invalid input or parameters"},
+    401: {"description": "Authentication required"},
+    403: {"description": "Forbidden — insufficient permissions or wrong team"},
+    404: {"description": "Resource not found"},
+    409: {"description": "Conflict — duplicate resource"},
+    422: {"description": "Validation error — invalid request body"},
+}
 
-@router.post("", response_model=User, status_code=201)
+
+@router.post(
+    "",
+    response_model=User,
+    status_code=201,
+    responses={k: _E[k] for k in (400, 401, 403, 404, 409)},
+)
 @limit_write
 async def create_user(
     request: Request,
@@ -105,7 +119,7 @@ async def create_user(
     return db_user
 
 
-@router.get("")
+@router.get("", responses={k: _E[k] for k in (401, 403)})
 @limit_read
 async def list_users(
     request: Request,
@@ -166,7 +180,11 @@ async def list_users(
     }
 
 
-@router.get("/{user_id}", response_model=UserWithTeam)
+@router.get(
+    "/{user_id}",
+    response_model=UserWithTeam,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_read
 async def get_user(
     request: Request,
@@ -197,8 +215,16 @@ async def get_user(
     return user_dict
 
 
-@router.patch("/{user_id}", response_model=User)
-@router.put("/{user_id}", response_model=User)
+@router.patch(
+    "/{user_id}",
+    response_model=User,
+    responses={k: _E[k] for k in (401, 403, 404, 409)},
+)
+@router.put(
+    "/{user_id}",
+    response_model=User,
+    responses={k: _E[k] for k in (401, 403, 404, 409)},
+)
 @limit_write
 async def update_user(
     request: Request,
@@ -271,7 +297,11 @@ async def update_user(
     return user
 
 
-@router.delete("/{user_id}", status_code=204)
+@router.delete(
+    "/{user_id}",
+    status_code=204,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_write
 async def deactivate_user(
     request: Request,
@@ -304,7 +334,11 @@ async def deactivate_user(
     )
 
 
-@router.post("/{user_id}/reactivate", response_model=User)
+@router.post(
+    "/{user_id}/reactivate",
+    response_model=User,
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
 @limit_write
 async def reactivate_user(
     request: Request,


### PR DESCRIPTION
## Summary

Closes #226.

Adds `responses=` documentation to all 33 endpoint decorators across `assets.py`, `proposals.py`, `users.py`, and `teams.py`.

Each file gets a module-level `_E` dict with standard HTTP error descriptions. Per-endpoint responses are composed via dict comprehension (`{k: _E[k] for k in (...)}`) selecting only the codes that endpoint can actually return:

- `400` — bad request / invalid input
- `401` — authentication required
- `403` — forbidden / insufficient permissions
- `404` — resource not found
- `409` — conflict / duplicate
- `412` — precondition failed (audit required, contracts only)

## Test plan
- [ ] All 1041 existing tests pass (no behavior change)
- [ ] `GET /docs` OpenAPI UI shows error responses on each endpoint
- [ ] `GET /openapi.json` contains the documented status codes