### PR TITLE
feat: add asset context endpoint

### DIFF
--- a/src/tessera/api/asset_context.py
+++ b/src/tessera/api/asset_context.py
@@ -1,0 +1,87 @@
+"""Asset context endpoint — single-call aggregation of all asset data."""
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tessera.api.auth import Auth, RequireRead
+from tessera.api.errors import BadRequestError, ErrorCode, NotFoundError
+from tessera.api.rate_limit import limit_read
+from tessera.db import AssetDB, get_session
+from tessera.services.asset_context import get_asset_context
+
+router = APIRouter()
+
+_E: dict[int, dict[str, str]] = {
+    400: {"description": "Bad request — invalid input or parameters"},
+    401: {"description": "Authentication required"},
+    403: {"description": "Forbidden — insufficient permissions or wrong team"},
+    404: {"description": "Not found — asset does not exist"},
+    422: {"description": "Validation error — check request format"},
+}
+
+
+@router.get(
+    "/{asset_id}/context",
+    responses={k: _E[k] for k in (401, 403, 404)},
+)
+@limit_read
+async def get_asset_context_by_id(
+    request: Request,
+    asset_id: UUID,
+    auth: Auth,
+    _: None = RequireRead,
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
+    """Get full context for an asset by ID.
+
+    Returns a composed view with asset metadata, current contract, consumers,
+    upstream/downstream lineage, active proposals, and recent audit runs.
+    Requires READ scope.
+    """
+    asset = await _load_asset_by_id(session, asset_id)
+    return await get_asset_context(session, asset)
+
+
+@router.get(
+    "/context",
+    responses={k: _E[k] for k in (400, 401, 403, 404)},
+)
+@limit_read
+async def get_asset_context_by_fqn(
+    request: Request,
+    auth: Auth,
+    fqn: str = Query(..., min_length=1, description="Fully qualified name of the asset"),
+    _: None = RequireRead,
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
+    """Get full context for an asset by FQN.
+
+    Returns a composed view with asset metadata, current contract, consumers,
+    upstream/downstream lineage, active proposals, and recent audit runs.
+    Requires READ scope.
+    """
+    if not fqn.strip():
+        raise BadRequestError("FQN parameter cannot be empty")
+
+    result = await session.execute(
+        select(AssetDB).where(AssetDB.fqn == fqn).where(AssetDB.deleted_at.is_(None))
+    )
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise NotFoundError(ErrorCode.ASSET_NOT_FOUND, f"Asset with FQN '{fqn}' not found")
+    return await get_asset_context(session, asset)
+
+
+async def _load_asset_by_id(session: AsyncSession, asset_id: UUID) -> AssetDB:
+    """Load an asset by ID, raising 404 if not found or deleted."""
+    result = await session.execute(
+        select(AssetDB).where(AssetDB.id == asset_id).where(AssetDB.deleted_at.is_(None))
+    )
+    asset = result.scalar_one_or_none()
+    if not asset:
+        raise NotFoundError(ErrorCode.ASSET_NOT_FOUND, "Asset not found")
+    return asset

--- a/src/tessera/main.py
+++ b/src/tessera/main.py
@@ -22,6 +22,7 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from tessera.api import (
     api_keys,
+    asset_context,
     assets,
     audit,
     audits,
@@ -200,6 +201,7 @@ register_login_required_handler(app)
 api_v1 = APIRouter(prefix="/api/v1")
 api_v1.include_router(users.router, prefix="/users", tags=["users"])
 api_v1.include_router(teams.router, prefix="/teams", tags=["teams"])
+api_v1.include_router(asset_context.router, prefix="/assets", tags=["assets"])
 api_v1.include_router(assets.router, prefix="/assets", tags=["assets"])
 api_v1.include_router(audits.router, prefix="/assets", tags=["audits"])
 api_v1.include_router(dependencies.router, prefix="/assets", tags=["dependencies"])

--- a/src/tessera/services/asset_context.py
+++ b/src/tessera/services/asset_context.py
@@ -1,0 +1,252 @@
+"""Asset context service — single-call aggregation of all asset data.
+
+Loads asset metadata, current contract, consumers, lineage, proposals,
+and recent audit runs sequentially on a single session.
+"""
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tessera.db.models import (
+    AssetDB,
+    AssetDependencyDB,
+    AuditRunDB,
+    ContractDB,
+    ProposalDB,
+    RegistrationDB,
+    TeamDB,
+)
+from tessera.models.enums import ContractStatus, ProposalStatus, RegistrationStatus
+
+
+async def _load_current_contract(session: AsyncSession, asset_id: UUID) -> ContractDB | None:
+    """Load the most recent active contract for an asset."""
+    result = await session.execute(
+        select(ContractDB)
+        .where(ContractDB.asset_id == asset_id)
+        .where(ContractDB.status == ContractStatus.ACTIVE)
+        .order_by(ContractDB.published_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _load_consumers(session: AsyncSession, asset_id: UUID) -> list[dict[str, Any]]:
+    """Load active consumer registrations for the asset's active contracts."""
+    # Find active contracts for this asset
+    contracts_result = await session.execute(
+        select(ContractDB.id)
+        .where(ContractDB.asset_id == asset_id)
+        .where(ContractDB.status == ContractStatus.ACTIVE)
+    )
+    contract_ids = [row[0] for row in contracts_result.all()]
+    if not contract_ids:
+        return []
+
+    # Find active registrations with team info
+    regs_result = await session.execute(
+        select(RegistrationDB, TeamDB)
+        .join(TeamDB, RegistrationDB.consumer_team_id == TeamDB.id)
+        .where(RegistrationDB.contract_id.in_(contract_ids))
+        .where(RegistrationDB.deleted_at.is_(None))
+        .where(RegistrationDB.status == RegistrationStatus.ACTIVE)
+        .where(TeamDB.deleted_at.is_(None))
+    )
+
+    consumers: list[dict[str, Any]] = []
+    for reg, team in regs_result.all():
+        consumers.append(
+            {
+                "registration_id": str(reg.id),
+                "consumer_team_id": str(team.id),
+                "consumer_team_name": team.name,
+                "pinned_version": reg.pinned_version,
+                "status": str(reg.status),
+                "registered_at": reg.registered_at.isoformat(),
+            }
+        )
+    return consumers
+
+
+async def _load_upstream_dependencies(
+    session: AsyncSession, asset_id: UUID
+) -> list[dict[str, Any]]:
+    """Load assets that this asset depends on (upstream)."""
+    result = await session.execute(
+        select(AssetDB, AssetDependencyDB.dependency_type)
+        .join(AssetDependencyDB, AssetDependencyDB.dependency_asset_id == AssetDB.id)
+        .where(AssetDependencyDB.dependent_asset_id == asset_id)
+        .where(AssetDependencyDB.deleted_at.is_(None))
+        .where(AssetDB.deleted_at.is_(None))
+    )
+    return [
+        {
+            "asset_id": str(asset.id),
+            "fqn": asset.fqn,
+            "resource_type": str(asset.resource_type),
+            "dependency_type": str(dep_type),
+        }
+        for asset, dep_type in result.all()
+    ]
+
+
+async def _load_downstream_dependents(
+    session: AsyncSession, asset_id: UUID
+) -> list[dict[str, Any]]:
+    """Load assets that depend on this asset (downstream, depth=1)."""
+    result = await session.execute(
+        select(AssetDB, AssetDependencyDB.dependency_type)
+        .join(AssetDependencyDB, AssetDependencyDB.dependent_asset_id == AssetDB.id)
+        .where(AssetDependencyDB.dependency_asset_id == asset_id)
+        .where(AssetDependencyDB.deleted_at.is_(None))
+        .where(AssetDB.deleted_at.is_(None))
+    )
+    return [
+        {
+            "asset_id": str(asset.id),
+            "fqn": asset.fqn,
+            "resource_type": str(asset.resource_type),
+            "dependency_type": str(dep_type),
+        }
+        for asset, dep_type in result.all()
+    ]
+
+
+async def _load_active_proposals(session: AsyncSession, asset_id: UUID) -> list[dict[str, Any]]:
+    """Load pending proposals for this asset."""
+    result = await session.execute(
+        select(ProposalDB)
+        .where(ProposalDB.asset_id == asset_id)
+        .where(ProposalDB.status == ProposalStatus.PENDING)
+        .order_by(ProposalDB.proposed_at.desc())
+    )
+    proposals: list[dict[str, Any]] = []
+    for proposal in result.scalars().all():
+        proposals.append(
+            {
+                "id": str(proposal.id),
+                "change_type": str(proposal.change_type),
+                "status": str(proposal.status),
+                "proposed_at": proposal.proposed_at.isoformat(),
+                "breaking_changes_count": len(proposal.breaking_changes),
+            }
+        )
+    return proposals
+
+
+async def _load_recent_audits(
+    session: AsyncSession, asset_id: UUID, limit: int = 5
+) -> list[dict[str, Any]]:
+    """Load the most recent audit runs for this asset."""
+    result = await session.execute(
+        select(AuditRunDB)
+        .where(AuditRunDB.asset_id == asset_id)
+        .order_by(AuditRunDB.run_at.desc())
+        .limit(limit)
+    )
+    audits: list[dict[str, Any]] = []
+    for run in result.scalars().all():
+        audits.append(
+            {
+                "id": str(run.id),
+                "status": str(run.status),
+                "guarantees_checked": run.guarantees_checked,
+                "guarantees_passed": run.guarantees_passed,
+                "guarantees_failed": run.guarantees_failed,
+                "triggered_by": run.triggered_by,
+                "run_at": run.run_at.isoformat(),
+            }
+        )
+    return audits
+
+
+async def _load_contract_history_count(session: AsyncSession, asset_id: UUID) -> int:
+    """Count total published contract versions for this asset."""
+    result = await session.execute(
+        select(func.count(ContractDB.id)).where(ContractDB.asset_id == asset_id)
+    )
+    return result.scalar_one()
+
+
+async def get_asset_context(session: AsyncSession, asset: AssetDB) -> dict[str, Any]:
+    """Build the full asset context response.
+
+    Loads all related data sequentially on the provided session. AsyncSession
+    wraps a single connection and cannot be shared across concurrent coroutines
+    (asyncio.gather would raise InterfaceError on asyncpg).
+
+    Args:
+        session: Database session.
+        asset: The asset to build context for (must already be loaded).
+
+    Returns:
+        Complete asset context dictionary.
+    """
+    asset_id = asset.id
+
+    current_contract = await _load_current_contract(session, asset_id)
+    consumers = await _load_consumers(session, asset_id)
+    upstream = await _load_upstream_dependencies(session, asset_id)
+    downstream = await _load_downstream_dependents(session, asset_id)
+    active_proposals = await _load_active_proposals(session, asset_id)
+    recent_audits = await _load_recent_audits(session, asset_id)
+    contract_history_count = await _load_contract_history_count(session, asset_id)
+
+    # Build asset section
+    asset_section: dict[str, Any] = {
+        "id": str(asset.id),
+        "fqn": asset.fqn,
+        "description": asset.metadata_.get("description"),
+        "tags": asset.metadata_.get("tags", []),
+        "resource_type": str(asset.resource_type),
+        "environment": asset.environment,
+        "owner_team_id": str(asset.owner_team_id),
+        "owner_team_name": asset.owner_team.name if asset.owner_team else None,
+        "owner_user_id": str(asset.owner_user_id) if asset.owner_user_id else None,
+        "compatibility_mode": None,
+        "guarantee_mode": str(asset.guarantee_mode),
+    }
+
+    # Build contract section
+    contract_section: dict[str, Any] | None = None
+    if current_contract:
+        asset_section["compatibility_mode"] = str(current_contract.compatibility_mode)
+
+        # Extract field-level annotations from schema properties
+        schema = current_contract.schema_def
+        properties = schema.get("properties", {})
+        field_descriptions: dict[str, str] = {}
+        field_tags: dict[str, list[str]] = {}
+        for field_name, field_def in properties.items():
+            if isinstance(field_def, dict):
+                desc = field_def.get("description")
+                if desc:
+                    field_descriptions[field_name] = desc
+                tags = field_def.get("tags")
+                if tags:
+                    field_tags[field_name] = tags
+
+        contract_section = {
+            "id": str(current_contract.id),
+            "version": current_contract.version,
+            "schema": current_contract.schema_def,
+            "field_descriptions": field_descriptions,
+            "field_tags": field_tags,
+            "guarantees": current_contract.guarantees,
+            "status": str(current_contract.status),
+            "published_at": current_contract.published_at.isoformat(),
+        }
+
+    return {
+        "asset": asset_section,
+        "current_contract": contract_section,
+        "consumers": consumers,
+        "upstream_dependencies": upstream,
+        "downstream_dependents": downstream,
+        "active_proposals": active_proposals,
+        "recent_audits": recent_audits,
+        "contract_history_count": contract_history_count,
+    }

--- a/tests/test_asset_context.py
+++ b/tests/test_asset_context.py
@@ -1,0 +1,355 @@
+"""Tests for the asset context endpoint."""
+
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import make_asset, make_contract, make_schema, make_team
+
+
+@pytest.mark.asyncio
+async def test_asset_context_full_data(client: AsyncClient) -> None:
+    """Test context endpoint returns all sections when data exists."""
+    # Create team
+    team_resp = await client.post("/api/v1/teams", json=make_team("context-team"))
+    assert team_resp.status_code == 201
+    team_id = team_resp.json()["id"]
+
+    # Create asset
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.analytics.dim_customers", team_id),
+    )
+    assert asset_resp.status_code == 201
+    asset_id = asset_resp.json()["id"]
+
+    # Publish a contract
+    schema = make_schema(id="integer", name="string", email="string")
+    schema["properties"]["email"]["description"] = "Customer email address"
+    contract_resp = await client.post(
+        f"/api/v1/assets/{asset_id}/contracts?published_by={team_id}",
+        json=make_contract("1.0.0", schema),
+    )
+    assert contract_resp.status_code == 201
+
+    # Create a consumer team and register
+    consumer_resp = await client.post("/api/v1/teams", json=make_team("consumer-team"))
+    assert consumer_resp.status_code == 201
+    consumer_team_id = consumer_resp.json()["id"]
+
+    contract_id = contract_resp.json()["contract"]["id"]
+    reg_resp = await client.post(
+        f"/api/v1/registrations?contract_id={contract_id}",
+        json={
+            "consumer_team_id": consumer_team_id,
+        },
+    )
+    assert reg_resp.status_code == 201
+
+    # Create upstream asset and dependency
+    upstream_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.raw.customers_raw", team_id),
+    )
+    assert upstream_resp.status_code == 201
+    upstream_id = upstream_resp.json()["id"]
+
+    dep_resp = await client.post(
+        f"/api/v1/assets/{asset_id}/dependencies",
+        json={
+            "depends_on_asset_id": upstream_id,
+            "dependency_type": "consumes",
+        },
+    )
+    assert dep_resp.status_code == 201
+
+    # Create downstream asset and dependency
+    downstream_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.analytics.fct_orders", team_id),
+    )
+    assert downstream_resp.status_code == 201
+    downstream_id = downstream_resp.json()["id"]
+
+    dep_resp2 = await client.post(
+        f"/api/v1/assets/{downstream_id}/dependencies",
+        json={
+            "depends_on_asset_id": asset_id,
+            "dependency_type": "consumes",
+        },
+    )
+    assert dep_resp2.status_code == 201
+
+    # Submit an audit run
+    audit_resp = await client.post(
+        f"/api/v1/assets/{asset_id}/audit-results",
+        json={
+            "status": "passed",
+            "guarantees_checked": 3,
+            "guarantees_passed": 3,
+            "guarantees_failed": 0,
+            "triggered_by": "dbt_test",
+        },
+    )
+    assert audit_resp.status_code == 200
+
+    # Now fetch context
+    ctx_resp = await client.get(f"/api/v1/assets/{asset_id}/context")
+    assert ctx_resp.status_code == 200
+    data = ctx_resp.json()
+
+    # Verify asset section
+    assert data["asset"]["id"] == asset_id
+    assert data["asset"]["fqn"] == "prod.analytics.dim_customers"
+    assert data["asset"]["owner_team_id"] == team_id
+    assert data["asset"]["owner_team_name"] == "context-team"
+    assert data["asset"]["resource_type"] is not None
+
+    # Verify current contract section
+    assert data["current_contract"] is not None
+    assert data["current_contract"]["version"] == "1.0.0"
+    assert "properties" in data["current_contract"]["schema"]
+    assert data["current_contract"]["field_descriptions"]["email"] == "Customer email address"
+
+    # Verify consumers
+    assert len(data["consumers"]) == 1
+    assert data["consumers"][0]["consumer_team_name"] == "consumer-team"
+
+    # Verify upstream dependencies
+    assert len(data["upstream_dependencies"]) == 1
+    assert data["upstream_dependencies"][0]["fqn"] == "prod.raw.customers_raw"
+
+    # Verify downstream dependents
+    assert len(data["downstream_dependents"]) == 1
+    assert data["downstream_dependents"][0]["fqn"] == "prod.analytics.fct_orders"
+
+    # Verify recent audits
+    assert len(data["recent_audits"]) == 1
+    assert data["recent_audits"][0]["status"] == "passed"
+    assert data["recent_audits"][0]["guarantees_passed"] == 3
+
+    # Verify contract history count
+    assert data["contract_history_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_asset_context_no_contract(client: AsyncClient) -> None:
+    """Test context endpoint when asset has no contracts."""
+    team_resp = await client.post("/api/v1/teams", json=make_team("no-contract-team"))
+    team_id = team_resp.json()["id"]
+
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.raw.no_contract_asset", team_id),
+    )
+    asset_id = asset_resp.json()["id"]
+
+    ctx_resp = await client.get(f"/api/v1/assets/{asset_id}/context")
+    assert ctx_resp.status_code == 200
+    data = ctx_resp.json()
+
+    assert data["current_contract"] is None
+    assert data["consumers"] == []
+    assert data["contract_history_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_asset_context_no_consumers(client: AsyncClient) -> None:
+    """Test context endpoint when asset has a contract but no consumers."""
+    team_resp = await client.post("/api/v1/teams", json=make_team("no-consumers-team"))
+    team_id = team_resp.json()["id"]
+
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.analytics.no_consumers", team_id),
+    )
+    asset_id = asset_resp.json()["id"]
+
+    schema = make_schema(id="integer")
+    await client.post(
+        f"/api/v1/assets/{asset_id}/contracts?published_by={team_id}",
+        json=make_contract("1.0.0", schema),
+    )
+
+    ctx_resp = await client.get(f"/api/v1/assets/{asset_id}/context")
+    assert ctx_resp.status_code == 200
+    data = ctx_resp.json()
+
+    assert data["current_contract"] is not None
+    assert data["consumers"] == []
+
+
+@pytest.mark.asyncio
+async def test_asset_context_no_lineage(client: AsyncClient) -> None:
+    """Test context endpoint when asset has no dependencies."""
+    team_resp = await client.post("/api/v1/teams", json=make_team("no-lineage-team"))
+    team_id = team_resp.json()["id"]
+
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.analytics.no_lineage", team_id),
+    )
+    asset_id = asset_resp.json()["id"]
+
+    ctx_resp = await client.get(f"/api/v1/assets/{asset_id}/context")
+    assert ctx_resp.status_code == 200
+    data = ctx_resp.json()
+
+    assert data["upstream_dependencies"] == []
+    assert data["downstream_dependents"] == []
+
+
+@pytest.mark.asyncio
+async def test_asset_context_active_proposal(client: AsyncClient) -> None:
+    """Test context endpoint includes active proposals."""
+    team_resp = await client.post("/api/v1/teams", json=make_team("proposal-team"))
+    team_id = team_resp.json()["id"]
+
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.analytics.with_proposal", team_id),
+    )
+    asset_id = asset_resp.json()["id"]
+
+    # Publish initial contract
+    schema_v1 = make_schema(id="integer", name="string")
+    await client.post(
+        f"/api/v1/assets/{asset_id}/contracts?published_by={team_id}",
+        json=make_contract("1.0.0", schema_v1),
+    )
+
+    # Create a consumer so breaking change triggers a proposal
+    consumer_resp = await client.post("/api/v1/teams", json=make_team("proposal-consumer"))
+    consumer_team_id = consumer_resp.json()["id"]
+
+    # Get the contract ID
+    contracts_resp = await client.get(f"/api/v1/assets/{asset_id}/contracts")
+    contract_id = contracts_resp.json()["results"][0]["id"]
+
+    await client.post(
+        f"/api/v1/registrations?contract_id={contract_id}",
+        json={
+            "consumer_team_id": consumer_team_id,
+        },
+    )
+
+    # Publish breaking change (remove required field) — should create proposal
+    schema_v2 = make_schema(id="integer")  # removed "name"
+    await client.post(
+        f"/api/v1/assets/{asset_id}/contracts?published_by={team_id}",
+        json=make_contract("2.0.0", schema_v2),
+    )
+
+    ctx_resp = await client.get(f"/api/v1/assets/{asset_id}/context")
+    assert ctx_resp.status_code == 200
+    data = ctx_resp.json()
+
+    assert len(data["active_proposals"]) >= 1
+    proposal = data["active_proposals"][0]
+    assert proposal["status"] == "pending"
+    assert proposal["breaking_changes_count"] > 0
+
+
+@pytest.mark.asyncio
+async def test_asset_context_fqn_lookup(client: AsyncClient) -> None:
+    """Test context endpoint via FQN query parameter."""
+    team_resp = await client.post("/api/v1/teams", json=make_team("fqn-lookup-team"))
+    team_id = team_resp.json()["id"]
+
+    fqn = "prod.analytics.fqn_lookup_asset"
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset(fqn, team_id),
+    )
+    assert asset_resp.status_code == 201
+    asset_id = asset_resp.json()["id"]
+
+    ctx_resp = await client.get("/api/v1/assets/context", params={"fqn": fqn})
+    assert ctx_resp.status_code == 200
+    data = ctx_resp.json()
+
+    assert data["asset"]["id"] == asset_id
+    assert data["asset"]["fqn"] == fqn
+
+
+@pytest.mark.asyncio
+async def test_asset_context_deleted_asset(client: AsyncClient) -> None:
+    """Test context endpoint returns 404 for deleted asset."""
+    team_resp = await client.post("/api/v1/teams", json=make_team("deleted-team"))
+    team_id = team_resp.json()["id"]
+
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.analytics.to_delete", team_id),
+    )
+    asset_id = asset_resp.json()["id"]
+
+    # Delete the asset
+    del_resp = await client.delete(f"/api/v1/assets/{asset_id}")
+    assert del_resp.status_code == 204
+
+    # Context should 404
+    ctx_resp = await client.get(f"/api/v1/assets/{asset_id}/context")
+    assert ctx_resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_asset_context_missing_asset(client: AsyncClient) -> None:
+    """Test context endpoint returns 404 for non-existent asset."""
+    fake_id = str(uuid4())
+    ctx_resp = await client.get(f"/api/v1/assets/{fake_id}/context")
+    assert ctx_resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_asset_context_fqn_not_found(client: AsyncClient) -> None:
+    """Test context endpoint returns 404 for non-existent FQN."""
+    ctx_resp = await client.get("/api/v1/assets/context", params={"fqn": "nonexistent.fqn.asset"})
+    assert ctx_resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_asset_context_multiple_contracts(client: AsyncClient) -> None:
+    """Test context endpoint returns the active contract and correct history count."""
+    team_resp = await client.post("/api/v1/teams", json=make_team("multi-contract-team"))
+    team_id = team_resp.json()["id"]
+
+    asset_resp = await client.post(
+        "/api/v1/assets",
+        json=make_asset("prod.analytics.multi_contract", team_id),
+    )
+    asset_id = asset_resp.json()["id"]
+
+    # Publish two compatible versions (adding an optional field is backward-compatible)
+    schema_v1 = make_schema(id="integer")
+    resp1 = await client.post(
+        f"/api/v1/assets/{asset_id}/contracts?published_by={team_id}",
+        json=make_contract("1.0.0", schema_v1),
+    )
+    assert resp1.status_code == 201
+
+    # Add an optional property (not in "required") — backward-compatible
+    schema_v2 = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer"},
+            "name": {"type": "string"},
+        },
+        "required": ["id"],
+    }
+    resp2 = await client.post(
+        f"/api/v1/assets/{asset_id}/contracts?published_by={team_id}",
+        json=make_contract("1.1.0", schema_v2),
+    )
+    assert resp2.status_code == 201
+
+    ctx_resp = await client.get(f"/api/v1/assets/{asset_id}/context")
+    assert ctx_resp.status_code == 200
+    data = ctx_resp.json()
+
+    # Should return the latest active contract (old one was deprecated)
+    assert data["current_contract"] is not None
+    assert data["current_contract"]["version"] == "1.1.0"
+    # History count includes all versions
+    assert data["contract_history_count"] == 2


### PR DESCRIPTION
Implements single-call aggregation endpoint for comprehensive asset context data.

## What's new
- `GET /api/v1/assets/{asset_id}/context` — fetch asset by ID
- `GET /api/v1/assets/context?fqn=...` — fetch asset by fully qualified name
- Returns composed view with asset metadata, current contract, consumers, upstream/downstream lineage, active proposals, and recent audit runs

## How it works
Service layer in `services/asset_context.py` loads all 7 data sources sequentially on a single AsyncSession, maintaining SQLAlchemy concurrency safety for PostgreSQL (asyncpg). Auth requires READ scope; 404 for missing or deleted assets.

## Testing
10 comprehensive tests covering all acceptance criteria: full data, missing contracts, no consumers, no lineage, active proposals, deleted assets, FQN lookup edge cases, and multiple contract versions.