### PR TITLE
feat: complete semantic metadata for OpenAPI, GraphQL, bulk APIs

### DIFF
--- a/src/tessera/api/bulk.py
+++ b/src/tessera/api/bulk.py
@@ -267,6 +267,7 @@ async def bulk_create_assets(
                     resource_type=item.resource_type,
                     guarantee_mode=item.guarantee_mode,
                     metadata_=item.metadata,
+                    tags=item.tags,
                 )
                 session.add(asset)
                 await session.flush()

--- a/src/tessera/api/contracts.py
+++ b/src/tessera/api/contracts.py
@@ -455,6 +455,8 @@ async def bulk_publish_contracts(
                 schema_def=item.schema_def,
                 compatibility_mode=compat_mode,
                 guarantees=item.guarantees,
+                field_descriptions=item.field_descriptions,
+                field_tags=item.field_tags,
             )
         )
 

--- a/src/tessera/api/sync/graphql.py
+++ b/src/tessera/api/sync/graphql.py
@@ -246,6 +246,7 @@ async def import_graphql(
                         compatibility_mode=CompatibilityMode.BACKWARD,
                         guarantees=merged_guarantees,
                         field_descriptions=asset_def.field_descriptions,
+                        field_tags=asset_def.field_tags,
                         published_by=import_req.owner_team_id,
                     )
                     session.add(new_contract)

--- a/src/tessera/api/sync/openapi.py
+++ b/src/tessera/api/sync/openapi.py
@@ -238,6 +238,7 @@ async def import_openapi(
                         compatibility_mode=CompatibilityMode.BACKWARD,
                         guarantees=merged_guarantees,
                         field_descriptions=asset_def.field_descriptions,
+                        field_tags=asset_def.field_tags,
                         published_by=import_req.owner_team_id,
                     )
                     session.add(new_contract)

--- a/src/tessera/models/bulk.py
+++ b/src/tessera/models/bulk.py
@@ -73,6 +73,7 @@ class BulkAssetItem(BaseModel):
     resource_type: ResourceType = ResourceType.OTHER
     guarantee_mode: GuaranteeMode = GuaranteeMode.NOTIFY
     metadata: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list, description="Free-form labels for this asset")
 
     @field_validator("fqn")
     @classmethod
@@ -150,6 +151,12 @@ class BulkContractItem(BaseModel):
         "Uses asset default if not specified.",
     )
     guarantees: dict[str, Any] | None = Field(None, description="Contract guarantees")
+    field_descriptions: dict[str, str] = Field(
+        default_factory=dict, description="Map of JSON path -> human-readable field description"
+    )
+    field_tags: dict[str, list[str]] = Field(
+        default_factory=dict, description="Map of JSON path -> list of tags"
+    )
 
 
 class BulkContractRequest(BaseModel):

--- a/src/tessera/services/graphql.py
+++ b/src/tessera/services/graphql.py
@@ -113,6 +113,10 @@ def _graphql_type_to_json_schema(
             field_schema, is_required = _graphql_type_to_json_schema(
                 field_type, types_map, depth + 1
             )
+            # Preserve field descriptions from GraphQL introspection
+            field_desc = field.get("description")
+            if field_desc:
+                field_schema = {**field_schema, "description": field_desc}
             properties[field_name] = field_schema
             if is_required:
                 required.append(field_name)
@@ -386,6 +390,7 @@ class AssetFromGraphQL(BaseModel):
     schema_def: dict[str, Any]
     guarantees: dict[str, Any] | None = None
     field_descriptions: dict[str, str] = {}
+    field_tags: dict[str, list[str]] = {}
     description: str | None = None
 
 
@@ -430,6 +435,14 @@ def operations_to_assets(
             arg_desc = arg_info.get("description")
             if arg_name and arg_desc:
                 field_descs[f"$.properties.arguments.properties.{arg_name}"] = arg_desc
+
+        # Extract field descriptions from return type fields
+        return_props = op.return_type.get("properties", {})
+        for field_name, field_schema in return_props.items():
+            if isinstance(field_schema, dict):
+                desc = field_schema.get("description")
+                if desc:
+                    field_descs[f"$.properties.response.properties.{field_name}"] = desc
 
         assets.append(
             AssetFromGraphQL(

--- a/src/tessera/services/openapi.py
+++ b/src/tessera/services/openapi.py
@@ -443,6 +443,35 @@ def _extract_field_descriptions(
     return descriptions
 
 
+def _extract_field_tags(
+    schema: dict[str, Any],
+    prefix: str = "$.properties",
+) -> dict[str, list[str]]:
+    """Extract per-property tags from a JSON Schema via x-tessera extensions.
+
+    Looks for x-tessera.tags on each property to build a field-level tag map.
+    """
+    tags: dict[str, list[str]] = {}
+    if not isinstance(schema, dict):
+        return tags
+
+    properties = schema.get("properties", {})
+    for prop_name, prop_schema in properties.items():
+        path = f"{prefix}.{prop_name}"
+        if isinstance(prop_schema, dict):
+            tessera_ext = prop_schema.get("x-tessera", {})
+            if isinstance(tessera_ext, dict):
+                prop_tags = tessera_ext.get("tags")
+                if isinstance(prop_tags, list) and prop_tags:
+                    tags[path] = [str(t) for t in prop_tags]
+            # Recurse into nested objects
+            if prop_schema.get("type") == "object" and "properties" in prop_schema:
+                tags.update(_extract_field_tags(prop_schema, path + ".properties"))
+            if "items" in prop_schema and isinstance(prop_schema["items"], dict):
+                tags.update(_extract_field_tags(prop_schema["items"], path + ".items.properties"))
+    return tags
+
+
 class AssetFromOpenAPI(BaseModel):
     """Asset to be created from an OpenAPI endpoint."""
 
@@ -452,6 +481,7 @@ class AssetFromOpenAPI(BaseModel):
     schema_def: dict[str, Any]
     guarantees: dict[str, Any] | None = None
     field_descriptions: dict[str, str] = {}
+    field_tags: dict[str, list[str]] = {}
     tags: list[str] = []
     description: str | None = None
 
@@ -489,6 +519,7 @@ def endpoints_to_assets(
 
         # Extract field descriptions from the combined schema properties
         field_descs = _extract_field_descriptions(endpoint.combined_schema)
+        field_tags = _extract_field_tags(endpoint.combined_schema)
 
         # Asset description: prefer summary, fall back to operation description
         asset_description = endpoint.summary or endpoint.description
@@ -501,6 +532,7 @@ def endpoints_to_assets(
                 schema_def=endpoint.combined_schema,
                 guarantees=endpoint.guarantees,
                 field_descriptions=field_descs,
+                field_tags=field_tags,
                 tags=endpoint.tags,
                 description=asset_description,
             )

--- a/tests/test_semantic_metadata.py
+++ b/tests/test_semantic_metadata.py
@@ -608,6 +608,81 @@ class TestOpenAPISyncMetadata:
             == "Unique user identifier"
         )
 
+    async def test_openapi_sync_extracts_field_tags(self, client: AsyncClient) -> None:
+        """OpenAPI sync extracts x-tessera.tags from properties into field_tags."""
+        team_resp = await client.post("/api/v1/teams", json={"name": "openapi-ftags-team"})
+        team_id = team_resp.json()["id"]
+
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Field Tags API", "version": "1.0.0"},
+            "paths": {
+                "/accounts": {
+                    "get": {
+                        "operationId": "listAccounts",
+                        "summary": "List accounts",
+                        "tags": ["accounts"],
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "account_id": {
+                                                    "type": "integer",
+                                                    "description": "Account ID",
+                                                    "x-tessera": {
+                                                        "tags": ["join-key", "immutable"],
+                                                    },
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "x-tessera": {
+                                                        "tags": ["pii", "gdpr"],
+                                                    },
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                },
+                                            },
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+        }
+
+        resp = await client.post(
+            "/api/v1/sync/openapi",
+            json={
+                "spec": spec,
+                "owner_team_id": team_id,
+                "auto_publish_contracts": True,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["assets_created"] >= 1
+
+        asset_id = data["endpoints"][0]["asset_id"]
+
+        contracts_resp = await client.get(f"/api/v1/assets/{asset_id}/contracts")
+        assert contracts_resp.status_code == 200
+        contract = contracts_resp.json()["results"][0]
+
+        # field_tags should contain x-tessera tags
+        assert contract["field_tags"]["$.properties.response.properties.account_id"] == [
+            "join-key",
+            "immutable",
+        ]
+        assert contract["field_tags"]["$.properties.response.properties.email"] == ["pii", "gdpr"]
+        # status has no x-tessera tags
+        assert "$.properties.response.properties.status" not in contract["field_tags"]
+
 
 @pytest.mark.asyncio
 class TestGraphQLSyncMetadata:
@@ -716,6 +791,202 @@ class TestGraphQLSyncMetadata:
             contract["field_descriptions"]["$.properties.arguments.properties.id"]
             == "The user's unique identifier"
         )
+
+    async def test_graphql_sync_extracts_return_field_descriptions(
+        self, client: AsyncClient
+    ) -> None:
+        """GraphQL sync extracts descriptions from return type fields."""
+        team_resp = await client.post("/api/v1/teams", json={"name": "gql-ret-desc-team"})
+        team_id = team_resp.json()["id"]
+
+        introspection = {
+            "__schema": {
+                "queryType": {"name": "Query"},
+                "mutationType": None,
+                "types": [
+                    {
+                        "kind": "OBJECT",
+                        "name": "Query",
+                        "fields": [
+                            {
+                                "name": "product",
+                                "description": "Fetch a product by ID",
+                                "args": [],
+                                "type": {
+                                    "kind": "OBJECT",
+                                    "name": "Product",
+                                    "ofType": None,
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "kind": "OBJECT",
+                        "name": "Product",
+                        "fields": [
+                            {
+                                "name": "sku",
+                                "description": "Stock keeping unit code",
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": None,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": None,
+                                    },
+                                },
+                                "args": [],
+                            },
+                            {
+                                "name": "price",
+                                "description": "Current retail price in cents",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Int",
+                                    "ofType": None,
+                                },
+                                "args": [],
+                            },
+                            {
+                                "name": "in_stock",
+                                "description": None,
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": None,
+                                },
+                                "args": [],
+                            },
+                        ],
+                    },
+                    {"kind": "SCALAR", "name": "String"},
+                    {"kind": "SCALAR", "name": "Int"},
+                    {"kind": "SCALAR", "name": "Boolean"},
+                ],
+            }
+        }
+
+        resp = await client.post(
+            "/api/v1/sync/graphql",
+            json={
+                "introspection": introspection,
+                "schema_name": "ProductAPI",
+                "owner_team_id": team_id,
+                "auto_publish_contracts": True,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["assets_created"] >= 1
+
+        asset_id = data["operations"][0]["asset_id"]
+        contracts_resp = await client.get(f"/api/v1/assets/{asset_id}/contracts")
+        assert contracts_resp.status_code == 200
+        contract = contracts_resp.json()["results"][0]
+
+        # Return type field descriptions should be extracted
+        assert (
+            contract["field_descriptions"]["$.properties.response.properties.sku"]
+            == "Stock keeping unit code"
+        )
+        assert (
+            contract["field_descriptions"]["$.properties.response.properties.price"]
+            == "Current retail price in cents"
+        )
+        # Null description should not appear
+        assert "$.properties.response.properties.in_stock" not in contract["field_descriptions"]
+
+
+@pytest.mark.asyncio
+class TestBulkAPISemanticMetadata:
+    """Test bulk API endpoints with semantic metadata fields."""
+
+    async def test_bulk_create_assets_with_tags(self, client: AsyncClient) -> None:
+        """Bulk asset creation supports tags."""
+        team_resp = await client.post("/api/v1/teams", json={"name": "bulk-tags-team"})
+        team_id = team_resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/bulk/assets",
+            json={
+                "assets": [
+                    {
+                        "fqn": "bulk.tagged.table1",
+                        "owner_team_id": team_id,
+                        "tags": ["pii", "tier1"],
+                    },
+                    {
+                        "fqn": "bulk.tagged.table2",
+                        "owner_team_id": team_id,
+                        "tags": ["financial"],
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["succeeded"] == 2
+
+        # Verify tags were persisted
+        for result in data["results"]:
+            asset_resp = await client.get(f"/api/v1/assets/{result['id']}")
+            assert asset_resp.status_code == 200
+            asset = asset_resp.json()
+            if asset["fqn"] == "bulk.tagged.table1":
+                assert asset["tags"] == ["pii", "tier1"]
+            elif asset["fqn"] == "bulk.tagged.table2":
+                assert asset["tags"] == ["financial"]
+
+    async def test_bulk_publish_contracts_with_field_metadata(self, client: AsyncClient) -> None:
+        """Bulk contract publish supports field_descriptions and field_tags."""
+        team_resp = await client.post("/api/v1/teams", json={"name": "bulk-fmeta-team"})
+        team_id = team_resp.json()["id"]
+
+        asset_resp = await client.post(
+            "/api/v1/assets",
+            json={"fqn": "bulk.fmeta.table", "owner_team_id": team_id},
+        )
+        asset_id = asset_resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/contracts/bulk",
+            params={"dry_run": False},
+            json={
+                "published_by": team_id,
+                "contracts": [
+                    {
+                        "asset_id": asset_id,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "user_id": {"type": "integer"},
+                                "email": {"type": "string"},
+                            },
+                        },
+                        "field_descriptions": {
+                            "$.properties.user_id": "Primary key",
+                            "$.properties.email": "Contact email",
+                        },
+                        "field_tags": {
+                            "$.properties.user_id": ["join-key"],
+                            "$.properties.email": ["pii"],
+                        },
+                    }
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["published"] == 1
+
+        # Verify metadata was persisted on the contract
+        contract_id = data["results"][0]["contract_id"]
+        contract_resp = await client.get(f"/api/v1/contracts/{contract_id}")
+        assert contract_resp.status_code == 200
+        contract = contract_resp.json()
+        assert contract["field_descriptions"]["$.properties.user_id"] == "Primary key"
+        assert contract["field_tags"]["$.properties.email"] == ["pii"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes remaining gaps in #360 (semantic metadata for assets and contracts):

- **OpenAPI sync**: Extract per-field tags via `x-tessera.tags` property extensions, pass `field_tags` to contracts
- **GraphQL sync**: Extract field descriptions from return type fields (previously only args), propagate `description` through JSON Schema generation, pass `field_tags` to contracts  
- **Bulk API**: Add `tags` to `BulkAssetItem`, add `field_descriptions` and `field_tags` to `BulkContractItem`, thread through to service layer

## Test plan

- [x] All 1184 existing tests pass (0 regressions)
- [x] New test: OpenAPI field_tags extraction from x-tessera extensions
- [x] New test: GraphQL return type field description extraction
- [x] New test: Bulk asset creation with tags
- [x] New test: Bulk contract publish with field_descriptions and field_tags
- [x] ruff, ruff-format, mypy all pass