### PR TITLE
feat: add tessera-sdk examples to quickstart.py

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -3,53 +3,93 @@ Tessera Quickstart Examples
 ===========================
 5 core workflows demonstrating how to use Tessera for data contract coordination.
 
+Two approaches are shown for each workflow:
+  - HTTP (httpx): Direct REST API calls. No extra dependency beyond httpx.
+    Use this when you need fine-grained control, are integrating into an existing
+    HTTP-based pipeline, or want to avoid the SDK dependency.
+  - SDK (tessera-sdk): Higher-level client that handles pagination, error mapping,
+    and resource resolution. Use this for application code and scripts where
+    readability and maintainability matter more than raw control.
+
+Install the SDK:  pip install tessera-sdk
+
 This script is self-contained - it creates all the data it needs.
 
-Run with: uv run python examples/quickstart.py
+Run with:
+  HTTP mode:  uv run python examples/quickstart.py
+  SDK mode:   uv run python examples/quickstart.py --sdk
 """
 
-import os
+from __future__ import annotations
 
-import httpx
+import argparse
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Client setup
+# ---------------------------------------------------------------------------
 
 BASE_URL = "http://localhost:8000/api/v1"
+SERVER_URL = "http://localhost:8000"
 API_KEY = os.environ.get("TESSERA_API_KEY", "tessera-dev-key")
-CLIENT = httpx.Client(timeout=30.0, headers={"Authorization": f"Bearer {API_KEY}"})
 
 
-def setup():
+def _check_server_http() -> bool:
+    """Return True if the Tessera server is reachable via httpx."""
+    import httpx
+
+    try:
+        httpx.get(f"{SERVER_URL}/health", timeout=5.0)
+        return True
+    except httpx.ConnectError:
+        return False
+
+
+# ============================================================================
+# HTTP (httpx) implementation
+# ============================================================================
+
+
+def _get_http_client():
+    import httpx
+
+    return httpx.Client(timeout=30.0, headers={"Authorization": f"Bearer {API_KEY}"})
+
+
+def _unpack(resp_json: dict | list, key: str = "results") -> list:
+    """Extract list from paginated or raw response."""
+    if isinstance(resp_json, list):
+        return resp_json
+    return resp_json.get(key, resp_json) if isinstance(resp_json, dict) else []
+
+
+def setup_http(client):
     """Create the teams, asset, and initial contract needed for the examples."""
     print("Setting up test data...")
 
     # Create producer team
-    resp = CLIENT.post(f"{BASE_URL}/teams", json={"name": "data-platform"})
+    resp = client.post(f"{BASE_URL}/teams", json={"name": "data-platform"})
     if resp.status_code == 201:
         producer = resp.json()
     else:
-        # Team might already exist, try to find it
-        teams_resp = CLIENT.get(f"{BASE_URL}/teams").json()
-        teams = (
-            teams_resp.get("results", teams_resp) if isinstance(teams_resp, dict) else teams_resp
-        )
+        teams = _unpack(client.get(f"{BASE_URL}/teams").json())
         producer = next((t for t in teams if t["name"] == "data-platform"), None)
         if not producer:
-            raise Exception("Could not create or find data-platform team")
+            raise RuntimeError("Could not create or find data-platform team")
 
     # Create consumer team
-    resp = CLIENT.post(f"{BASE_URL}/teams", json={"name": "ml-team"})
+    resp = client.post(f"{BASE_URL}/teams", json={"name": "ml-team"})
     if resp.status_code == 201:
         consumer = resp.json()
     else:
-        teams_resp = CLIENT.get(f"{BASE_URL}/teams").json()
-        teams = (
-            teams_resp.get("results", teams_resp) if isinstance(teams_resp, dict) else teams_resp
-        )
+        teams = _unpack(client.get(f"{BASE_URL}/teams").json())
         consumer = next((t for t in teams if t["name"] == "ml-team"), None)
         if not consumer:
-            raise Exception("Could not create or find ml-team")
+            raise RuntimeError("Could not create or find ml-team")
 
     # Create an asset
-    resp = CLIENT.post(
+    resp = client.post(
         f"{BASE_URL}/assets",
         json={
             "fqn": "warehouse.analytics.dim_customers",
@@ -60,26 +100,18 @@ def setup():
     if resp.status_code == 201:
         asset = resp.json()
     else:
-        # Asset might already exist
-        assets_resp = CLIENT.get(f"{BASE_URL}/assets").json()
-        assets = (
-            assets_resp.get("results", assets_resp)
-            if isinstance(assets_resp, dict)
-            else assets_resp
+        assets = _unpack(client.get(f"{BASE_URL}/assets").json())
+        asset = next(
+            (a for a in assets if a["fqn"] == "warehouse.analytics.dim_customers"),
+            None,
         )
-        asset = next((a for a in assets if a["fqn"] == "warehouse.analytics.dim_customers"), None)
         if not asset:
-            raise Exception("Could not create or find asset")
+            raise RuntimeError("Could not create or find asset")
 
-    # Publish initial contract
-    contracts_resp = CLIENT.get(f"{BASE_URL}/assets/{asset['id']}/contracts").json()
-    contracts = (
-        contracts_resp.get("results", contracts_resp)
-        if isinstance(contracts_resp, dict)
-        else contracts_resp
-    )
+    # Publish initial contract if none active
+    contracts = _unpack(client.get(f"{BASE_URL}/assets/{asset['id']}/contracts").json())
     if not any(c["status"] == "active" for c in contracts):
-        resp = CLIENT.post(
+        resp = client.post(
             f"{BASE_URL}/assets/{asset['id']}/contracts",
             params={"published_by": producer["id"]},
             json={
@@ -98,68 +130,41 @@ def setup():
             },
         )
         if resp.status_code != 201:
-            raise Exception(f"Could not create contract: {resp.text}")
+            raise RuntimeError(f"Could not create contract: {resp.text}")
 
-    print(f"  Producer team: {producer['name']} ({producer['id']})")
-    print(f"  Consumer team: {consumer['name']} ({consumer['id']})")
-    print(f"  Asset: {asset['fqn']} ({asset['id']})")
-    print()
-
+    _print_setup(producer, consumer, asset)
     return producer, consumer, asset
 
 
-def example_1_register_as_consumer(asset: dict, consumer: dict):
-    """
-    EXAMPLE 1: Register as a Consumer
-    ---------------------------------
-    The ML team wants to use the customer data.
-    They register their dependency so they get notified of changes.
-    """
-    print("\n" + "=" * 70)
-    print("EXAMPLE 1: Register as a Consumer")
-    print("=" * 70)
+def example_1_http(asset: dict, consumer: dict, client):
+    """Register as a consumer (HTTP)."""
+    _print_header("EXAMPLE 1: Register as a Consumer")
 
-    # Get the active contract
-    contracts_resp = CLIENT.get(f"{BASE_URL}/assets/{asset['id']}/contracts").json()
-    contracts = (
-        contracts_resp.get("results", contracts_resp)
-        if isinstance(contracts_resp, dict)
-        else contracts_resp
-    )
+    contracts = _unpack(client.get(f"{BASE_URL}/assets/{asset['id']}/contracts").json())
     contract = next((c for c in contracts if c["status"] == "active"), None)
-
     if not contract:
         print("No active contract found.")
         return None
 
     print(f"Found contract: {contract['id']} (v{contract['version']})")
 
-    # Register as a consumer
-    resp = CLIENT.post(
+    resp = client.post(
         f"{BASE_URL}/registrations",
         params={"contract_id": contract["id"]},
         json={"consumer_team_id": consumer["id"]},
     )
     registration = resp.json()
 
-    print("\n✓ Registered as consumer!")
+    print("\nRegistered as consumer!")
     print(f"  Registration ID: {registration['id']}")
     print(f"  Status: {registration['status']}")
-
     return contract
 
 
-def example_2_check_impact(asset: dict):
-    """
-    EXAMPLE 2: Impact Analysis
-    --------------------------
-    Before making changes, check who would be affected.
-    """
-    print("\n" + "=" * 70)
-    print("EXAMPLE 2: Check Impact Before Making Changes")
-    print("=" * 70)
+def example_2_http(asset: dict, client):
+    """Check impact before making changes (HTTP)."""
+    _print_header("EXAMPLE 2: Check Impact Before Making Changes")
 
-    # Proposed schema that removes the 'email' field
     proposed_schema = {
         "type": "object",
         "properties": {
@@ -170,37 +175,31 @@ def example_2_check_impact(asset: dict):
         "required": ["customer_id"],
     }
 
-    impact = CLIENT.post(f"{BASE_URL}/assets/{asset['id']}/impact", json=proposed_schema).json()
+    impact = client.post(
+        f"{BASE_URL}/assets/{asset['id']}/impact-preview",
+        json={"proposed_schema": proposed_schema},
+    ).json()
 
-    print(f"\nChange type: {impact['change_type'].upper()}")
-    print(f"Safe to publish: {impact['safe_to_publish']}")
+    print(f"\nBreaking: {impact['is_breaking']}")
 
     if impact["breaking_changes"]:
-        print("\n⚠ Breaking changes detected:")
+        print("\nBreaking changes detected:")
         for bc in impact["breaking_changes"]:
             print(f"  - {bc['message']}")
 
-    if impact["impacted_consumers"]:
-        print("\n👥 Impacted consumers:")
-        for consumer in impact["impacted_consumers"]:
-            print(f"  - {consumer['team_name']} (status: {consumer['status']})")
+    if impact["affected_consumers"]:
+        print("\nAffected consumers:")
+        for c in impact["affected_consumers"]:
+            print(f"  - {c['team_name']} (status: {c['status']})")
 
     return impact
 
 
-def example_3_breaking_change_creates_proposal(asset: dict, producer: dict):
-    """
-    EXAMPLE 3: Breaking Change → Proposal
-    -------------------------------------
-    When you try to publish a breaking change, Tessera creates
-    a Proposal instead of breaking downstream consumers.
-    """
-    print("\n" + "=" * 70)
-    print("EXAMPLE 3: Breaking Change Creates a Proposal")
-    print("=" * 70)
+def example_3_http(asset: dict, producer: dict, client):
+    """Publish a breaking change, creating a proposal (HTTP)."""
+    _print_header("EXAMPLE 3: Breaking Change Creates a Proposal")
 
-    # Try to publish a breaking change (removing 'email')
-    result = CLIENT.post(
+    result = client.post(
         f"{BASE_URL}/assets/{asset['id']}/contracts",
         params={"published_by": producer["id"]},
         json={
@@ -209,8 +208,7 @@ def example_3_breaking_change_creates_proposal(asset: dict, producer: dict):
                 "type": "object",
                 "properties": {
                     "customer_id": {"type": "integer"},
-                    "full_name": {"type": "string"},  # renamed from 'name'
-                    # 'email' removed - breaking change!
+                    "full_name": {"type": "string"},
                 },
                 "required": ["customer_id"],
             },
@@ -222,29 +220,22 @@ def example_3_breaking_change_creates_proposal(asset: dict, producer: dict):
 
     if result["action"] == "proposal_created":
         print(f"Change type: {result['change_type']}")
-        print("\n⚠ Breaking changes:")
+        print("\nBreaking changes:")
         for bc in result["breaking_changes"]:
             print(f"  - {bc['message']}")
-        print("\n📋 Proposal created:")
-        print(f"  ID: {result['proposal']['id']}")
+        print(f"\nProposal created: {result['proposal']['id']}")
         print(f"  Status: {result['proposal']['status']}")
-        print("\n✓ Consumers must acknowledge before this goes live!")
+        print("\nConsumers must acknowledge before this goes live!")
         return result["proposal"]
 
     return None
 
 
-def example_4_acknowledge_proposal(proposal: dict, consumer: dict):
-    """
-    EXAMPLE 4: Consumer Acknowledges Proposal
-    -----------------------------------------
-    The affected team reviews and acknowledges the breaking change.
-    """
-    print("\n" + "=" * 70)
-    print("EXAMPLE 4: Consumer Acknowledges the Proposal")
-    print("=" * 70)
+def example_4_http(proposal: dict, consumer: dict, client):
+    """Consumer acknowledges a proposal (HTTP)."""
+    _print_header("EXAMPLE 4: Consumer Acknowledges the Proposal")
 
-    ack = CLIENT.post(
+    ack = client.post(
         f"{BASE_URL}/proposals/{proposal['id']}/acknowledge",
         json={
             "consumer_team_id": consumer["id"],
@@ -253,40 +244,23 @@ def example_4_acknowledge_proposal(proposal: dict, consumer: dict):
         },
     ).json()
 
-    print("\n✓ Proposal acknowledged!")
-    print(f"  Status: {ack.get('status', 'acknowledged')}")
-    print("  The consumer confirmed they're ready for the change.")
-
+    print("\nProposal acknowledged!")
+    print(f"  Response: {ack.get('response', 'approved')}")
     return ack
 
 
-def example_5_compatible_change_auto_publishes(asset: dict, producer: dict):
-    """
-    EXAMPLE 5: Compatible Change Auto-Publishes
-    -------------------------------------------
-    Adding new optional fields is backward compatible.
-    These changes publish automatically without needing approval.
-    """
-    print("\n" + "=" * 70)
-    print("EXAMPLE 5: Compatible Change Auto-Publishes")
-    print("=" * 70)
+def example_5_http(asset: dict, producer: dict, client):
+    """Publish a compatible change that auto-publishes (HTTP)."""
+    _print_header("EXAMPLE 5: Compatible Change Auto-Publishes")
 
-    # Get current contract
-    contracts_resp = CLIENT.get(f"{BASE_URL}/assets/{asset['id']}/contracts").json()
-    contracts = (
-        contracts_resp.get("results", contracts_resp)
-        if isinstance(contracts_resp, dict)
-        else contracts_resp
-    )
+    contracts = _unpack(client.get(f"{BASE_URL}/assets/{asset['id']}/contracts").json())
     current = next((c for c in contracts if c["status"] == "active"), None)
-
     if not current:
-        print("\n⚠ No active contract found.")
+        print("\nNo active contract found.")
         return None
 
     current_schema = current.get("schema_def") or current.get("schema", {})
 
-    # Add a new optional field (backward compatible)
     new_schema = {
         "type": "object",
         "properties": {
@@ -300,57 +274,309 @@ def example_5_compatible_change_auto_publishes(asset: dict, producer: dict):
         "required": current_schema.get("required", []),
     }
 
-    result = CLIENT.post(
+    result = client.post(
         f"{BASE_URL}/assets/{asset['id']}/contracts",
         params={"published_by": producer["id"]},
         json={"version": "1.1.0", "schema": new_schema, "compatibility_mode": "backward"},
     ).json()
 
     print(f"\nAction: {result['action']}")
-
     if result["action"] == "published":
         print(f"Change type: {result.get('change_type', 'minor')}")
-        print("\n✓ Auto-published! No approval needed.")
+        print("\nAuto-published! No approval needed.")
         print(f"  New version: {result['contract']['version']}")
         print("  Added: loyalty_tier field")
 
     return result
 
 
-def main():
-    """Run all examples."""
-    print("\n" + "🔷" * 35)
-    print("  TESSERA QUICKSTART EXAMPLES")
-    print("🔷" * 35 + "\n")
-
-    # Check server is running
+def run_http():
+    """Run all examples using raw httpx."""
+    client = _get_http_client()
     try:
-        CLIENT.get(f"{BASE_URL.replace('/api/v1', '')}/health")
-    except httpx.ConnectError:
-        print("❌ Server not running. Start it with:")
-        print("   uv run uvicorn tessera.main:app --reload")
-        return
-
-    try:
-        # Setup: create teams, asset, and initial contract
-        producer, consumer, asset = setup()
-
-        # Run examples
-        example_1_register_as_consumer(asset, consumer)
-        example_2_check_impact(asset)
-        proposal = example_3_breaking_change_creates_proposal(asset, producer)
+        producer, consumer, asset = setup_http(client)
+        example_1_http(asset, consumer, client)
+        example_2_http(asset, client)
+        proposal = example_3_http(asset, producer, client)
         if proposal:
-            example_4_acknowledge_proposal(proposal, consumer)
-        example_5_compatible_change_auto_publishes(asset, producer)
+            example_4_http(proposal, consumer, client)
+        example_5_http(asset, producer, client)
+    finally:
+        client.close()
 
-    except httpx.HTTPStatusError as e:
-        print(f"\n❌ HTTP Error: {e.response.status_code}")
-        print(e.response.text)
+
+# ============================================================================
+# SDK (tessera-sdk) implementation
+# ============================================================================
+
+
+def setup_sdk(client):
+    """Create the teams, asset, and initial contract needed for the examples."""
+    print("Setting up test data...")
+
+    # SDK handles errors and returns typed objects
+    producer = client.teams.create(name="data-platform")
+    consumer = client.teams.create(name="ml-team")
+
+    asset = client.assets.create(
+        fqn="warehouse.analytics.dim_customers",
+        owner_team_id=producer.id,
+        description="Customer dimension table",
+    )
+
+    # Publish initial contract
+    contracts = client.contracts.list(asset_id=asset.id)
+    if not any(c.status == "active" for c in contracts):
+        client.assets.publish_contract(
+            asset_id=asset.id,
+            version="1.0.0",
+            schema={
+                "type": "object",
+                "properties": {
+                    "customer_id": {"type": "integer"},
+                    "email": {"type": "string", "format": "email"},
+                    "name": {"type": "string"},
+                    "created_at": {"type": "string", "format": "date-time"},
+                },
+                "required": ["customer_id", "email"],
+            },
+            compatibility_mode="backward",
+        )
+
+    _print_setup_sdk(producer, consumer, asset)
+    return producer, consumer, asset
+
+
+def example_1_sdk(asset, consumer, client):
+    """Register as a consumer (SDK)."""
+    _print_header("EXAMPLE 1: Register as a Consumer")
+
+    # Find the active contract
+    contracts = client.contracts.list(asset_id=asset.id)
+    contract = next((c for c in contracts if c.status == "active"), None)
+    if not contract:
+        print("No active contract found.")
+        return None
+
+    print(f"Found contract: {contract.id} (v{contract.version})")
+
+    # One call to register - no need to build URLs or manage query params
+    registration = client.registrations.create(
+        contract_id=contract.id,
+        consumer_team_id=consumer.id,
+    )
+
+    print("\nRegistered as consumer!")
+    print(f"  Registration ID: {registration.id}")
+    print(f"  Status: {registration.status}")
+    return contract
+
+
+def example_2_sdk(asset, client):
+    """Check impact before making changes (SDK)."""
+    _print_header("EXAMPLE 2: Check Impact Before Making Changes")
+
+    proposed_schema = {
+        "type": "object",
+        "properties": {
+            "customer_id": {"type": "integer"},
+            "name": {"type": "string"},
+        },
+        "required": ["customer_id"],
+    }
+
+    # SDK wraps the request body for you
+    impact = client.assets.check_impact(
+        asset_id=asset.id,
+        proposed_schema=proposed_schema,
+    )
+
+    print(f"\nBreaking: {impact.is_breaking}")
+
+    if impact.breaking_changes:
+        print("\nBreaking changes detected:")
+        for bc in impact.breaking_changes:
+            print(f"  - {bc['message']}")
+
+    if impact.affected_consumers:
+        print("\nAffected consumers:")
+        for c in impact.affected_consumers:
+            print(f"  - {c['team_name']} (status: {c['status']})")
+
+    return impact
+
+
+def example_3_sdk(asset, producer, client):
+    """Publish a breaking change, creating a proposal (SDK)."""
+    _print_header("EXAMPLE 3: Breaking Change Creates a Proposal")
+
+    result = client.assets.publish_contract(
+        asset_id=asset.id,
+        version="2.0.0",
+        schema={
+            "type": "object",
+            "properties": {
+                "customer_id": {"type": "integer"},
+                "full_name": {"type": "string"},
+            },
+            "required": ["customer_id"],
+        },
+        compatibility_mode="backward",
+    )
+
+    print(f"\nAction: {result.action}")
+
+    if result.action == "proposal_created":
+        print(f"Change type: {result.change_type}")
+        print("\nBreaking changes:")
+        for bc in result.breaking_changes:
+            print(f"  - {bc['message']}")
+        print(f"\nProposal created: {result.proposal.id}")
+        print(f"  Status: {result.proposal.status}")
+        print("\nConsumers must acknowledge before this goes live!")
+        return result.proposal
+
+    return None
+
+
+def example_4_sdk(proposal, consumer, client):
+    """Consumer acknowledges a proposal (SDK)."""
+    _print_header("EXAMPLE 4: Consumer Acknowledges the Proposal")
+
+    ack = client.proposals.acknowledge(
+        proposal_id=proposal.id,
+        team_id=consumer.id,
+        accepted=True,
+        comment="We've updated our ML pipeline. Ready for the change.",
+    )
+
+    print("\nProposal acknowledged!")
+    print(f"  Response: {ack.response}")
+    return ack
+
+
+def example_5_sdk(asset, producer, client):
+    """Publish a compatible change that auto-publishes (SDK)."""
+    _print_header("EXAMPLE 5: Compatible Change Auto-Publishes")
+
+    # Get current active contract's schema
+    contracts = client.contracts.list(asset_id=asset.id)
+    current = next((c for c in contracts if c.status == "active"), None)
+    if not current:
+        print("\nNo active contract found.")
+        return None
+
+    current_schema = current.schema
+
+    new_schema = {
+        "type": "object",
+        "properties": {
+            **current_schema.get("properties", {}),
+            "loyalty_tier": {
+                "type": "string",
+                "enum": ["bronze", "silver", "gold", "platinum"],
+                "description": "Customer loyalty program tier",
+            },
+        },
+        "required": current_schema.get("required", []),
+    }
+
+    result = client.assets.publish_contract(
+        asset_id=asset.id,
+        version="1.1.0",
+        schema=new_schema,
+        compatibility_mode="backward",
+    )
+
+    print(f"\nAction: {result.action}")
+    if result.action == "published":
+        print(f"Change type: {result.change_type}")
+        print("\nAuto-published! No approval needed.")
+        print(f"  New version: {result.contract.version}")
+        print("  Added: loyalty_tier field")
+
+    return result
+
+
+def run_sdk():
+    """Run all examples using the tessera-sdk."""
+    try:
+        from tessera_sdk import TesseraClient
+    except ImportError:
+        print("tessera-sdk is not installed. Install it with:")
+        print("  pip install tessera-sdk")
+        sys.exit(1)
+
+    with TesseraClient(base_url=SERVER_URL, api_key=API_KEY) as client:
+        producer, consumer, asset = setup_sdk(client)
+        example_1_sdk(asset, consumer, client)
+        example_2_sdk(asset, client)
+        proposal = example_3_sdk(asset, producer, client)
+        if proposal:
+            example_4_sdk(proposal, consumer, client)
+        example_5_sdk(asset, producer, client)
+
+
+# ============================================================================
+# Shared helpers
+# ============================================================================
+
+
+def _print_header(title: str) -> None:
+    print("\n" + "=" * 70)
+    print(title)
+    print("=" * 70)
+
+
+def _print_setup(producer: dict, consumer: dict, asset: dict) -> None:
+    print(f"  Producer team: {producer['name']} ({producer['id']})")
+    print(f"  Consumer team: {consumer['name']} ({consumer['id']})")
+    print(f"  Asset: {asset['fqn']} ({asset['id']})")
+    print()
+
+
+def _print_setup_sdk(producer, consumer, asset) -> None:
+    print(f"  Producer team: {producer.name} ({producer.id})")
+    print(f"  Consumer team: {consumer.name} ({consumer.id})")
+    print(f"  Asset: {asset.fqn} ({asset.id})")
+    print()
+
+
+# ============================================================================
+# Entry point
+# ============================================================================
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tessera quickstart examples")
+    parser.add_argument(
+        "--sdk",
+        action="store_true",
+        help="Use the tessera-sdk client instead of raw httpx",
+    )
+    args = parser.parse_args()
+
+    mode = "SDK (tessera-sdk)" if args.sdk else "HTTP (httpx)"
+    print(f"\n{'=' * 70}")
+    print(f"  TESSERA QUICKSTART EXAMPLES  [{mode}]")
+    print(f"{'=' * 70}\n")
+
+    if not _check_server_http():
+        print("Server not running. Start it with:")
+        print("  uv run uvicorn tessera.main:app --reload")
+        sys.exit(1)
+
+    try:
+        if args.sdk:
+            run_sdk()
+        else:
+            run_http()
     except Exception as e:
-        print(f"\n❌ Error: {e}")
+        print(f"\nError: {e}")
+        sys.exit(1)
 
     print("\n" + "=" * 70)
-    print("✅ All examples complete!")
+    print("All examples complete!")
     print("=" * 70 + "\n")
 
 


### PR DESCRIPTION
## Summary

- Adds `tessera-sdk` examples alongside existing HTTP (httpx) examples for all 5 core workflows in `examples/quickstart.py`
- Users select mode via `--sdk` flag: `uv run python examples/quickstart.py --sdk`
- Fixes the HTTP impact endpoint path (`/impact-preview` not `/impact`) and request body shape (`{"proposed_schema": ...}` wrapper)
- Refactors shared logic (headers, unpacking paginated responses) into helpers

Closes #231

## Test plan

- [x] All 1261 existing tests pass
- [x] Ruff lint and format checks pass
- [x] Script syntax validates
- [ ] Manual: run `uv run python examples/quickstart.py` against a running server (HTTP mode)
- [ ] Manual: run `uv run python examples/quickstart.py --sdk` with `tessera-sdk` installed (SDK mode)