### PR TITLE
fix: renumber duplicate Alembic migration 016

### DIFF
--- a/alembic/versions/017_add_agent_identity.py
+++ b/alembic/versions/017_add_agent_identity.py
@@ -1,7 +1,7 @@
 """Add agent identity columns to API keys and audit events.
 
-Revision ID: 016
-Revises: 015
+Revision ID: 017
+Revises: 016
 Create Date: 2026-03-13
 
 Adds:
@@ -21,8 +21,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "016"
-down_revision: str = "015"
+revision: str = "017"
+down_revision: str = "016"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary

- Renumbers `016_add_agent_identity.py` → `017_add_agent_identity.py` and updates its `revision`/`down_revision` to restore a linear migration chain: `015 → 016 (semantic_metadata) → 017 (agent_identity)`
- semantic_metadata (#372) was merged before agent_identity (#371), so it retains revision 016

## Test plan

- [x] Migration chain verified programmatically: `015 → 016 → 017`
- [x] Full test suite passes (1261 passed)
- [x] `ruff check`, `ruff format`, `mypy` all clean

Fixes #378