### PR TITLE
fix: log warning on lenient semver fallback, capture previous_version in audit

### DIFF
--- a/src/tessera/services/audit.py
+++ b/src/tessera/services/audit.py
@@ -128,21 +128,31 @@ async def log_contract_published(
     change_type: str | None = None,
     force: bool = False,
     prerelease: bool = False,
+    previous_version: str | None = None,
 ) -> AuditEventDB:
-    """Log a contract publication event."""
+    """Log a contract publication event.
+
+    Args:
+        previous_version: Raw version string of the contract being superseded.
+            Captured so the audit trail preserves the original value even when
+            lenient parsing normalized it for version-bump computation.
+    """
     action = AuditAction.CONTRACT_FORCE_PUBLISHED if force else AuditAction.CONTRACT_PUBLISHED
+    payload: dict[str, Any] = {
+        "version": version,
+        "change_type": change_type,
+        "force": force,
+        "prerelease": prerelease,
+    }
+    if previous_version is not None:
+        payload["previous_version"] = previous_version
     return await log_event(
         session=session,
         entity_type="contract",
         entity_id=contract_id,
         action=action,
         actor_id=publisher_id,
-        payload={
-            "version": version,
-            "change_type": change_type,
-            "force": force,
-            "prerelease": prerelease,
-        },
+        payload=payload,
     )
 
 

--- a/src/tessera/services/contract_publisher.py
+++ b/src/tessera/services/contract_publisher.py
@@ -384,6 +384,7 @@ async def bulk_publish_contracts(
                             publisher_id=published_by,
                             version=suggested_version,
                             change_type=str(diff_result.change_type.value),
+                            previous_version=current_contract.version,
                         )
 
                         # Log guarantee changes if guarantees differ
@@ -901,6 +902,7 @@ class ContractPublishingWorkflow:
                 publisher_id=self.published_by,
                 version=contract.version,
                 change_type=str(diff_result.change_type),
+                previous_version=self.current_contract.version,
             )
             await invalidate_asset(str(self.asset.id))
             await cache_contract(str(contract.id), Contract.model_validate(contract).model_dump())
@@ -921,6 +923,7 @@ class ContractPublishingWorkflow:
                 version=contract.version,
                 change_type=str(diff_result.change_type),
                 force=True,
+                previous_version=self.current_contract.version,
             )
             await invalidate_asset(str(self.asset.id))
             await cache_contract(str(contract.id), Contract.model_validate(contract).model_dump())
@@ -943,6 +946,7 @@ class ContractPublishingWorkflow:
                 version=contract.version,
                 change_type=str(diff_result.change_type),
                 prerelease=True,
+                previous_version=self.current_contract.version,
             )
             await invalidate_asset(str(self.asset.id))
             await cache_contract(str(contract.id), Contract.model_validate(contract).model_dump())
@@ -964,6 +968,7 @@ class ContractPublishingWorkflow:
                 publisher_id=self.published_by,
                 version=contract.version,
                 change_type=str(diff_result.change_type),
+                previous_version=self.current_contract.version,
             )
             await invalidate_asset(str(self.asset.id))
             await cache_contract(str(contract.id), Contract.model_validate(contract).model_dump())

--- a/src/tessera/services/versioning.py
+++ b/src/tessera/services/versioning.py
@@ -6,11 +6,14 @@ Other modules import from this module rather than defining their own.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Final
 
 if TYPE_CHECKING:
     from tessera.models import VersionSuggestion
     from tessera.models.enums import ChangeType
+
+logger = logging.getLogger(__name__)
 
 INITIAL_VERSION: Final[str] = "1.0.0"
 """Version assigned to the first contract published for an asset."""
@@ -44,10 +47,17 @@ def parse_semver_lenient(version: str) -> tuple[int, int, int]:
     Use this when you need a best-effort parse that never raises, e.g.
     when handling versions that may have been stored before validation
     was enforced.
+
+    Logs a warning when falling back so malformed versions don't go
+    unnoticed in the audit trail.
     """
     try:
         return parse_semver(version)
     except ValueError:
+        logger.warning(
+            "Malformed version string %r could not be parsed; falling back to (1, 0, 0)",
+            version,
+        )
         return (1, 0, 0)
 
 

--- a/tests/test_audit_api.py
+++ b/tests/test_audit_api.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from tessera.db.models import AuditEventDB, Base
 from tessera.main import app
+from tessera.services.audit import log_contract_published
 
 TEST_DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 _USE_SQLITE = TEST_DATABASE_URL.startswith("sqlite")
@@ -316,7 +317,9 @@ class TestAuditFiltering:
         assert result["entity_type"] == "type1"
         assert result["action"] == "action1"
 
-    async def test_filter_returns_empty_for_no_matches(self, session: AsyncSession, client: AsyncClient):
+    async def test_filter_returns_empty_for_no_matches(
+        self, session: AsyncSession, client: AsyncClient
+    ):
         """Filter returns empty list if no matches."""
         e1 = AuditEventDB(
             entity_type="asset",
@@ -331,3 +334,31 @@ class TestAuditFiltering:
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
         assert resp.json()["results"] == []
+
+
+class TestLogContractPublished:
+    """Tests for the log_contract_published audit helper."""
+
+    async def test_previous_version_included_in_payload(self, session: AsyncSession) -> None:
+        """When previous_version is provided, it appears in the audit payload."""
+        contract_id = uuid4()
+        publisher_id = uuid4()
+        event = await log_contract_published(
+            session=session,
+            contract_id=contract_id,
+            publisher_id=publisher_id,
+            version="2.0.0",
+            previous_version="not-a-version",
+        )
+        assert event.payload["previous_version"] == "not-a-version"
+        assert event.payload["version"] == "2.0.0"
+
+    async def test_previous_version_omitted_when_none(self, session: AsyncSession) -> None:
+        """When previous_version is None, it is not present in the payload."""
+        event = await log_contract_published(
+            session=session,
+            contract_id=uuid4(),
+            publisher_id=uuid4(),
+            version="1.0.0",
+        )
+        assert "previous_version" not in event.payload

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,5 +1,7 @@
 """Tests for the consolidated versioning module."""
 
+import logging
+
 import pytest
 
 from tessera.services.versioning import (
@@ -49,6 +51,26 @@ class TestParseSemverLenient:
 
     def test_invalid_returns_default(self) -> None:
         assert parse_semver_lenient("garbage") == (1, 0, 0)
+
+    def test_valid_version_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="tessera.services.versioning"):
+            parse_semver_lenient("2.0.0")
+        assert caplog.records == []
+
+    def test_malformed_version_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="tessera.services.versioning"):
+            result = parse_semver_lenient("not-a-version")
+        assert result == (1, 0, 0)
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+        assert "not-a-version" in caplog.records[0].message
+
+    def test_empty_string_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="tessera.services.versioning"):
+            result = parse_semver_lenient("")
+        assert result == (1, 0, 0)
+        assert len(caplog.records) == 1
+        assert "''" in caplog.records[0].message
 
 
 class TestIsPrerelease:


### PR DESCRIPTION
## Summary

- `parse_semver_lenient` now logs a `WARNING` with the original version string when it falls back to `(1, 0, 0)`, making malformed stored versions visible in application logs
- `log_contract_published` accepts an optional `previous_version` parameter — all contract publisher call sites that supersede an existing contract now pass the raw previous version into the audit payload
- Added tests for warning log behavior (valid versions don't warn, malformed versions do) and audit payload correctness (`previous_version` present when provided, absent when not)

Closes #384

## Test plan

- [x] `test_malformed_version_logs_warning` — verifies warning is emitted with original string
- [x] `test_valid_version_does_not_warn` — verifies no warning for valid versions
- [x] `test_empty_string_logs_warning` — verifies empty string case
- [x] `test_previous_version_included_in_payload` — verifies audit event contains `previous_version`
- [x] `test_previous_version_omitted_when_none` �� verifies no spurious key when not applicable
- [x] Full test suite: 1285 passed, 0 failures