### PR TITLE
docs: remove commercial framing from strategy docs

### DIFF
--- a/docs/strategy/README.md
+++ b/docs/strategy/README.md
@@ -7,7 +7,7 @@ Working documents for strategic analysis and planning.
 | Document | Status | Topic |
 |----------|--------|-------|
 | [Agent Opportunity](agent-opportunity.md) | Draft | AI agents as first-class data consumers and producers |
-| [Data Control Plane Pivot](data-control-plane.md) | Draft | Reframing from "data contracts" to "data control plane" |
+| [Data Control Plane](data-control-plane.md) | Draft | Evolution from contract coordination to data control plane |
 | [Passive Discovery](passive-discovery.md) | Draft | Automatic dependency detection from query logs and lineage |
 
 ## How These Connect
@@ -16,6 +16,6 @@ The three documents form a coherent strategic picture:
 
 1. **Passive discovery** solves the cold-start problem that limits Tessera's current value. Without a complete dependency graph, coordination is unreliable.
 2. **Agent opportunity** expands the user base from human data teams to AI agents — the fastest-growing consumer category. Passive discovery makes agent registration automatic (via preflight audit conversion).
-3. **Data control plane** reframes the product from a coordination tool to infrastructure. Passive discovery provides the observability layer. Agent integration provides the automation layer. Together they justify the "control plane" positioning.
+3. **Data control plane** describes the end state: a system that observes actual data state, reconciles it with declared contracts, enforces policies, and automates remediation. Passive discovery provides the observability layer. Agent integration provides the automation layer.
 
-Build order: passive discovery (Phase 1: preflight inference) → MCP server → warehouse connectors → policy engine → control plane messaging.
+Build order: passive discovery (Phase 1: preflight inference) → MCP server → warehouse connectors → policy engine.

--- a/docs/strategy/agent-opportunity.md
+++ b/docs/strategy/agent-opportunity.md
@@ -209,50 +209,9 @@ Human teams can negotiate migration paths in meetings. Agents can't. If an agent
 
 ---
 
-## Competitive Positioning
-
-### What No One Else Has
-
-No open-source tool combines:
-1. Schema change detection across multiple formats
-2. Producer-consumer coordination workflow
-3. AI agent identity and accountability
-4. Machine-readable preflight checks
-5. Migration suggestion generation
-
-The closest competitors lack the coordination layer entirely:
-- **DataContract CLI**: Validates and diffs, but has no producer-consumer relationship, no proposals, no agent identity.
-- **Confluent Schema Registry**: Has compatibility modes, but is Kafka-only with no warehouse support, no agent features, no coordination workflow.
-- **Soda**: Has "data contracts" branding, but they're unilateral quality checks with no consumer registration, no dependency tracking.
-- **dbt contracts**: Has `contract: {enforced: true}`, but it's producer-side only, dbt-only, no cross-system support.
-
-### The Moat Question
-
-Features can be copied. The moat has to come from one of:
-
-1. **Ecosystem gravity.** If Tessera becomes the way dbt users handle breaking changes, and the way agents discover schemas, the integration surface becomes the moat. This requires the MCP server and deep dbt integration.
-
-2. **Dependency graph completeness.** The value of the coordination layer scales superlinearly with the completeness of the dependency graph. A tool with 90% coverage is 10x more valuable than one with 50% coverage. Passive discovery is how you get to 90%. First tool to have a comprehensive graph wins, because migrating away means rebuilding the graph.
-
-3. **Standard-setting.** If Tessera's contract format becomes the way people describe data interfaces — the way OpenAPI became the way people describe REST APIs — the standard itself is the moat. This requires community adoption, not just technical superiority.
-
----
-
 ## Risks
 
-### Risk 1: dbt Labs ships native coordination
-
-dbt already has `contract: {enforced: true}`. If dbt Labs adds consumer registration and breaking change proposals to dbt Cloud, Tessera's primary on-ramp closes. **Mitigation:** Tessera works across dbt, OpenAPI, GraphQL, gRPC, Avro. dbt can only coordinate within dbt. Position Tessera as the cross-system coordination layer, with dbt as one input among many.
-
-### Risk 2: Agent frameworks build their own schema discovery
-
-LangChain, CrewAI, or others could build native schema discovery that bypasses Tessera. **Mitigation:** Schema discovery without coordination is read-only. It tells you what exists today but doesn't help you manage change. Tessera's value is the coordination, not just the catalog.
-
-### Risk 3: The agent market isn't ready
-
-Enterprises might not adopt agent-to-data patterns at scale for another 2-3 years. **Mitigation:** The human coordination use case is viable today. Agent features are additive, not a replacement. Building for agents doesn't require abandoning the human use case.
-
-### Risk 4: Registration cold-start kills adoption
+### Risk 1: Registration cold-start kills adoption
 
 If the dependency graph is empty, impact analysis is useless, and the coordination workflow notifies no one. Agents won't register voluntarily. **Mitigation:** Passive discovery (see [Passive Discovery](passive-discovery.md)) and dbt sync (automatic dependency extraction from manifests) are the two paths to bootstrap the graph without requiring manual registration.
 
@@ -283,23 +242,3 @@ If the dependency graph is empty, impact analysis is useless, and the coordinati
 8. **Agent confidence scoring.** Let agent publishers declare confidence in their schemas. Low-confidence triggers additional review.
 
 9. **Schema convention enforcement.** Flag agent-generated schemas that deviate from conventions established by prior versions of the same asset.
-
----
-
-## The Positioning Question
-
-Two viable framings:
-
-**Option A: "Data contracts for data teams, with first-class agent support."**
-- Safer. Addresses the existing buyer (data engineering leads).
-- Agent features are a differentiator, not the pitch.
-- Risk: sounds incremental. Doesn't capture the agent opportunity's full upside.
-
-**Option B: "The schema intelligence layer for AI agents and data teams."**
-- Bolder. Addresses the emerging buyer (platform engineering, AI infrastructure).
-- Positions Tessera at the intersection of data governance and AI safety.
-- Risk: the "AI agent" buyer doesn't have established budgets yet.
-
-**Recommendation: Option A for now, with a migration path to Option B.** Ship the MCP server. Let agent adoption grow organically through the MCP distribution channel. When agent usage hits a meaningful percentage of traffic (visible in audit trail via `actor_type` filtering), pivot the messaging to Option B with data to back it up.
-
-The audit trail is the canary. When `actor_type=agent` events exceed `actor_type=human` events on a deployment, you'll know the pivot is overdue.

--- a/docs/strategy/data-control-plane.md
+++ b/docs/strategy/data-control-plane.md
@@ -1,21 +1,16 @@
-# Data Control Plane Pivot
+# Data Control Plane
 
 **Status:** Draft
 **Date:** 2026-03-29
 **Author:** Evan Volgas
 
-## The Argument
+## The Idea
 
 Compute has Kubernetes. Networking has service meshes. Storage has S3 lifecycle policies. Data has nothing.
 
-There is no system that manages the lifecycle, interfaces, and dependencies of data assets across an organization. Catalogs describe what exists (Atlan, DataHub, Collibra). Quality tools check what arrived (Monte Carlo, Soda, Great Expectations). Observability tools detect when things broke (Monte Carlo, Bigeye). None of them coordinate change. None of them manage the operational relationship between producers and consumers.
+There is no system that manages the lifecycle, interfaces, and dependencies of data assets across an organization. Catalogs describe what exists. Quality tools check what arrived. Observability tools detect when things broke. None of them coordinate change. None of them manage the operational relationship between producers and consumers.
 
-"Data contract coordination" describes what Tessera does. "Data control plane" describes what Tessera is becoming. The distinction matters because:
-
-- **"Data contracts"** sounds like a governance obligation. It connotes compliance, process, overhead. The buyer is a data governance lead who needs to check a box.
-- **"Data control plane"** sounds like infrastructure. It connotes reliability, automation, operational intelligence. The buyer is a platform engineering lead who needs to keep things running.
-
-Same product. Different frame. Different buyer. Different market size.
+"Data contract coordination" describes what Tessera does today. "Data control plane" describes what Tessera is becoming. Contract coordination is one capability of a control plane — the part that manages change propagation. A full control plane also observes actual state, reconciles it with declared state, enforces policies, and automates remediation.
 
 ---
 
@@ -82,7 +77,7 @@ Tessera already implements most of these primitives. What's missing is the opera
 
 ### 1. Observability of Actual State
 
-Tessera knows the declared state (contracts, registrations) but not the actual state (what's really happening in the warehouse). The gap:
+Tessera knows the declared state (contracts, registrations) but not the actual state (what's really happening in the warehouse).
 
 | Question | Can Tessera answer it today? |
 |----------|------------------------------|
@@ -93,13 +88,13 @@ Tessera knows the declared state (contracts, registrations) but not the actual s
 | When was this table last updated? | Only if freshness guarantee is configured and audited |
 | Is this table growing normally? | No (volume anomaly detection doesn't exist) |
 
-A control plane must reconcile declared state with actual state. Tessera currently trusts declarations. That's governance. A control plane verifies.
+A control plane must reconcile declared state with actual state. Tessera currently trusts declarations. A control plane verifies.
 
 **What to build:** Scheduled reconciliation that fetches actual schemas from warehouses and compares them to the active contract. Drift detection: "the `orders` table in Snowflake has a column `discount_code` that doesn't exist in the contract." This is the data equivalent of Kubernetes detecting a pod that doesn't match its deployment spec.
 
 ### 2. Passive Discovery
 
-Covered in detail in [Passive Discovery](passive-discovery.md). In the control plane frame: a control plane that only knows about explicitly registered dependencies is like Kubernetes only knowing about pods you manually tell it about. The system must discover what exists.
+Covered in detail in [Passive Discovery](passive-discovery.md). A control plane that only knows about explicitly registered dependencies is like Kubernetes only knowing about pods you manually tell it about. The system must discover what exists.
 
 ### 3. Automated Remediation
 
@@ -123,7 +118,7 @@ Acknowledgment policies (from the [Agent Opportunity](agent-opportunity.md) doc)
 - **Freshness policies:** "If `orders` is staler than 2 hours, mark preflight as `fresh: false`."
 - **Deprecation policies:** "If a column hasn't been queried in 90 days, flag for deprecation."
 
-Policies are declarative rules that the control plane evaluates continuously. They replace manual decisions with automated ones, which is exactly what makes a control plane a control plane rather than a dashboard.
+Policies are declarative rules that the control plane evaluates continuously. They replace manual decisions with automated ones — which is what makes a control plane a control plane rather than a dashboard.
 
 ### 5. Federation
 
@@ -135,126 +130,77 @@ This is a later-stage feature but it's architecturally significant. The current 
 
 ---
 
-## The Pivot Path
+## Evolution Path
 
-This is not a big-bang repositioning. It's a gradual expansion of scope, where each step adds a control plane capability and the messaging shifts to match.
+Each stage adds control plane capabilities. The system graduates from coordination tool to full control plane incrementally.
 
 ### Stage 1: Coordination Tool (Today — v0.2)
 
-**What it is:** Schema change coordination between teams.
-**Messaging:** "Data contract coordination for warehouses."
-**Buyer:** Data engineering leads who feel the pain of uncoordinated schema changes.
-**What proves it works:** Teams using the proposal workflow. Breaking changes caught before deployment.
+Schema change coordination between teams. Publishing, compatibility checks, proposal-acknowledgment workflow.
+
+**Milestone:** Teams using the proposal workflow. Breaking changes caught before deployment.
 
 ### Stage 2: Coordination + Intelligence (Next — v0.3)
 
-**What to add:**
+**Additions:**
 - Preflight-to-inference pipeline (passive discovery Phase 1)
 - Coverage report (graph completeness visibility)
 - MCP server (agent distribution)
 - Dependency graph unification
 
-**Messaging shift:** "Data contract coordination with dependency intelligence."
-**Buyer:** Same, but now platform engineering is interested because of the coverage report and agent integration.
-**What proves it works:** Dependency graph coverage >60% on deployed instances. Agents connecting via MCP.
+**Milestone:** Dependency graph coverage >60% on deployed instances. Agents connecting via MCP.
 
 ### Stage 3: Intelligence + Observability (Later — v0.4)
 
-**What to add:**
+**Additions:**
 - Warehouse connector for schema drift detection (Snowflake first)
 - Passive discovery from query logs
 - Column-level dependency tracking
 - Reconciliation loop (declared vs actual schema)
 
-**Messaging shift:** "The data control plane — know what you have, who depends on it, and what's changing."
-**Buyer:** Platform engineering leads. The pitch is no longer "coordinate schema changes" but "operational visibility and control over your data ecosystem."
-**What proves it works:** Schema drift detection catches real discrepancies. Impact analysis uses column-level dependencies from query logs.
+**Milestone:** Schema drift detection catches real discrepancies. Impact analysis uses column-level dependencies from query logs.
 
 ### Stage 4: Full Control Plane (v1.0)
 
-**What to add:**
+**Additions:**
 - Policy engine (acknowledgment, publishing, discovery, deprecation policies)
 - Automated remediation (drift → auto-publish, stale → alert, unused → deprecate)
 - Additional warehouse connectors (BigQuery, Databricks, Redshift)
 - Federation between instances
 
-**Messaging:** "The control plane for your data ecosystem."
-**Buyer:** VP of Data / Head of Platform Engineering. The pitch is: "You have Kubernetes for compute, Terraform for infrastructure, Tessera for data."
-**What proves it works:** Organizations running Tessera as infrastructure (always-on, multiple teams, policy-driven) rather than a tool (used occasionally for specific changes).
+**Milestone:** Organizations running Tessera as infrastructure (always-on, multiple teams, policy-driven) rather than a tool used occasionally for specific changes.
 
 ---
 
-## What Not to Do
+## Scope Boundaries
 
 ### Don't Build a Catalog
 
-Catalogs (Atlan, DataHub, Collibra) are well-funded, well-established, and have large engineering teams. Tessera should not try to replace them. The differentiation is:
-
-- Catalogs answer: "What data do we have?"
-- Tessera answers: "What happens when this data changes?"
-
-These are complementary, not competitive. Tessera should integrate with catalogs (push contract metadata to DataHub, pull asset descriptions from Atlan) rather than replace them.
+Catalogs are a solved problem. Tessera's question is "what happens when this data changes?" — not "what data do we have?" Integrate with catalogs (push contract metadata, pull asset descriptions) rather than replacing them.
 
 ### Don't Build a Data Quality Tool
 
-Monte Carlo, Soda, and Great Expectations own data quality monitoring. Tessera tracks quality guarantees and gates publishing on audit results — it doesn't run the audits. The `triggered_by` field on `AuditRunDB` reflects this: Tessera receives results from dbt tests, GX checkpoints, or Soda scans. It doesn't compete with them.
+Tessera tracks quality guarantees and gates publishing on audit results — it doesn't run the audits. The `triggered_by` field on `AuditRunDB` reflects this: Tessera receives results from dbt tests, GX checkpoints, or Soda scans.
 
 ### Don't Build a Lineage Visualizer
 
-Lineage visualization is a catalog feature. Tessera has lineage data (the dependency graph), and it should expose this data via API for other tools to visualize. But building a lineage UI is a distraction from the control plane mission.
+Tessera has lineage data (the dependency graph) and should expose it via API for other tools to visualize. Building a lineage UI is a distraction from the control plane mission.
 
 ### Don't Generalize Beyond Data (Yet)
 
-The panel discussion surfaced the idea that Tessera's coordination model could apply to any schema-bearing interface (APIs, ML models, event streams). This is true in principle but dangerous in practice. Generalizing prematurely diffuses focus. Win data first. The generalization is a reward, not a strategy.
+Tessera's coordination model could apply to any schema-bearing interface (APIs, ML models, event streams). But generalizing prematurely diffuses focus. Win data first. The generalization is a reward for getting the core right.
 
 ---
 
-## Competitive Implications
-
-### Against Catalogs (Atlan, DataHub, Collibra)
-
-**Position:** "Catalogs describe. Tessera coordinates." Tessera is not a replacement for a catalog — it's the operational layer that catalogs don't provide. Integrate, don't compete. The ideal outcome is that Atlan/DataHub users also run Tessera for change management.
-
-### Against Data Quality (Monte Carlo, Soda)
-
-**Position:** "Quality tools detect failures after the fact. Tessera prevents them before deployment." Monte Carlo tells you your dashboard broke. Tessera prevents the schema change that would have broken it.
-
-### Against dbt
-
-**Position:** "dbt transforms data. Tessera coordinates the interfaces between transforms." Tessera is dbt's coordination layer, not its competitor. The dbt integration is the most important wedge. The risk (dbt builds native coordination) is mitigated by Tessera's cross-system support.
-
-### Against Schema Registries (Confluent)
-
-**Position:** "Schema registries handle one transport (Kafka). Tessera handles the whole ecosystem." A single data org has warehouse tables, REST APIs, event streams, and GraphQL endpoints. A schema registry covers one of these. Tessera covers all of them.
-
----
-
-## The Portfolio Case
-
-For Tessera as a portfolio piece, the control plane framing elevates the project from "a useful tool" to "a system design achievement."
-
-What evaluators should notice:
-1. **The primitive model is complete.** Assets, contracts, registrations, proposals, acknowledgments, audit events — these are the right primitives for a data control plane, analogous to pods, services, deployments, and events in Kubernetes.
-2. **The coordination workflow is novel.** No other open-source tool implements proposal-acknowledgment for data schema changes. This is a genuinely new design pattern.
-3. **The architecture anticipates scale.** Async-first, separate rate limiting for agents, circuit breakers on webhooks, bounded queues, recursive graph traversal with depth limits — these are production concerns, not prototype concerns.
-4. **The agent integration is forward-looking.** Agent identity, preflight checks, semantic metadata, and MCP readiness position the project at the intersection of two trends (data governance + AI agents) before the market has converged.
-5. **The ADR trail documents reasoning.** 13 ADRs explaining not just what was built but why, with alternatives considered and tradeoffs acknowledged. This is how staff engineers think.
-
-The control plane frame makes these qualities visible to someone evaluating the project in 30 minutes.
-
----
-
-## Success Criteria for the Pivot
-
-The pivot is working when:
+## Success Criteria
 
 | Signal | Meaning |
 |--------|---------|
-| Users describe Tessera as "infrastructure" not "a tool" | It's perceived as always-on, not occasionally-used |
-| Platform engineering teams adopt it (not just data engineering) | The buyer has expanded beyond the original niche |
-| Dependency graph coverage exceeds 80% on deployed instances | Passive discovery is working; the graph is trusted |
-| Agent traffic exceeds 30% of total API calls | Agents are first-class participants, not an afterthought |
-| At least 3 warehouse connectors in production use | Cross-system coverage is real, not just dbt |
+| Tessera is treated as infrastructure, not a tool | It's always-on, not occasionally-used |
+| Platform engineering teams adopt it | Scope has expanded beyond data engineering |
+| Dependency graph coverage exceeds 80% | Passive discovery is working; the graph is trusted |
+| Agent traffic exceeds 30% of total API calls | Agents are first-class participants |
+| At least 3 warehouse connectors in production use | Cross-system coverage is real |
 | Policy engine handles >50% of acknowledgments automatically | Automation has replaced manual coordination for routine changes |
 
-None of these require abandoning the current product. Each is an incremental addition that shifts the value proposition from coordination tool to control plane. The code doesn't pivot. The framing does.
+None of these require abandoning the current product. Each is an incremental addition that shifts the system from coordination tool to control plane. The code doesn't pivot. The capabilities expand.


### PR DESCRIPTION
## Summary

- Removed buyer personas, competitive positioning, and go-to-market language from `data-control-plane.md` and `agent-opportunity.md`
- Tessera is an open source project with no commercial intentions — the strategy docs should describe what the system is becoming, not who might buy it
- Net removal of ~115 lines of content that didn't belong

## What was removed

**`data-control-plane.md`**: "The Argument" section (buyer persona framing), "Competitive Implications" section (positioning against Atlan, Monte Carlo, dbt, Confluent), "The Portfolio Case" section, per-stage "Buyer" and "Messaging" lines. Renamed from "Data Control Plane Pivot" to "Data Control Plane".

**`agent-opportunity.md`**: "Competitive Positioning" section (moat analysis, competitor comparison table), "The Positioning Question" section (buyer targeting, Option A vs Option B), and Risks 1-3 which were market-oriented rather than technical.

**`strategy/README.md`**: Updated title and description to match the revised docs.

## Why

Some of this commercial language was hallucinated by a prior Claude session that generated these strategy docs. It invented buyer personas, competitive positioning against named companies, and portfolio pitch framing that was never part of the project's intent. The technical content (architecture vision, gap analysis, evolution path, implementation plans) was sound and has been preserved.

## Test plan

- [x] Verified no remaining references to "buyer", "competitive", "market size", or similar commercial language in docs/
- [x] Confirmed cross-references between strategy docs still resolve correctly
- [x] Pre-commit hooks pass