### PR TITLE
fix: return HTTP 207 on partial failure in bulk endpoints

### DIFF
--- a/docs/api/contracts.md
+++ b/docs/api/contracts.md
@@ -214,6 +214,8 @@ Publish multiple contracts in a single request. Useful for CI/CD pipelines.
 
 ### Response
 
+Returns **200** when all items succeed, or **207 Multi-Status** when any items fail.
+
 ```json
 {
   "results": [

--- a/docs/api/sync.md
+++ b/docs/api/sync.md
@@ -40,15 +40,24 @@ Full manifest sync with automation options.
 
 #### Response
 
+Returns **200** when all operations succeed, or **207 Multi-Status** when any contract publishes or consumer registrations fail (partial success).
+
 ```json
 {
   "status": "success",
   "assets": { "created": 10, "updated": 5, "skipped": 2, "deleted": 1, "deleted_fqns": ["db.schema.old_model"] },
   "contracts": { "published": 8 },
   "proposals": { "created": 2 },
-  "registrations": { "created": 15 }
+  "registrations": { "created": 15 },
+  "contract_warnings": [],
+  "registration_warnings": []
 }
 ```
+
+| Status | `status` field | Meaning |
+|--------|---------------|---------|
+| 200 | `"success"` | All operations completed successfully |
+| 207 | `"partial_success"` | Some contract publishes or registrations failed; check `contract_warnings` and `registration_warnings` |
 
 ### Legacy Sync
 

--- a/src/tessera/api/bulk.py
+++ b/src/tessera/api/bulk.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -51,6 +51,7 @@ async def bulk_create_registrations(
     request: Request,
     auth: Auth,
     bulk_request: BulkRegistrationRequest,
+    response: Response,
     _: None = RequireWrite,
     session: AsyncSession = Depends(get_session),
 ) -> BulkRegistrationResponse:
@@ -182,6 +183,9 @@ async def bulk_create_registrations(
             )
             failed += 1
 
+    if failed > 0:
+        response.status_code = 207
+
     return BulkRegistrationResponse(
         total=len(bulk_request.registrations),
         succeeded=succeeded,
@@ -196,6 +200,7 @@ async def bulk_create_assets(
     request: Request,
     auth: Auth,
     bulk_request: BulkAssetRequest,
+    response: Response,
     _: None = RequireWrite,
     session: AsyncSession = Depends(get_session),
 ) -> BulkAssetResponse:
@@ -315,6 +320,9 @@ async def bulk_create_assets(
             )
             failed += 1
 
+    if failed > 0:
+        response.status_code = 207
+
     return BulkAssetResponse(
         total=len(bulk_request.assets),
         succeeded=succeeded,
@@ -372,6 +380,7 @@ async def bulk_acknowledge_proposals(
     request: Request,
     auth: Auth,
     bulk_request: BulkAcknowledgmentRequest,
+    response: Response,
     _: None = RequireWrite,
     session: AsyncSession = Depends(get_session),
 ) -> BulkAcknowledgmentResponse:
@@ -523,6 +532,9 @@ async def bulk_acknowledge_proposals(
             failed += 1
             if not bulk_request.continue_on_error:
                 break
+
+    if failed > 0:
+        response.status_code = 207
 
     return BulkAcknowledgmentResponse(
         total=len(bulk_request.acknowledgments),

--- a/src/tessera/api/sync/dbt/upload.py
+++ b/src/tessera/api/sync/dbt/upload.py
@@ -3,7 +3,7 @@
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -175,6 +175,7 @@ async def upload_dbt_manifest(
     request: Request,
     upload_req: DbtManifestUploadRequest,
     auth: Auth,
+    response: Response,
     _: None = RequireAdmin,
     session: AsyncSession = Depends(get_session),
 ) -> dict[str, Any]:
@@ -461,8 +462,12 @@ async def upload_dbt_manifest(
         },
     )
 
+    has_failures = bool(contract_warnings or registration_warnings)
+    if has_failures:
+        response.status_code = 207
+
     return {
-        "status": "success",
+        "status": "partial_success" if has_failures else "success",
         "conflict_mode": conflict_mode,
         "assets": {
             "created": assets_created,

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -139,7 +139,7 @@ class TestBulkRegistrations:
             json={"registrations": [{"contract_id": contract_id, "consumer_team_id": consumer_id}]},
         )
 
-        # Second bulk create should fail
+        # Second bulk create should fail with 207
         resp = await client.post(
             "/api/v1/bulk/registrations",
             json={
@@ -147,7 +147,7 @@ class TestBulkRegistrations:
                 "skip_duplicates": False,
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["failed"] == 1
         assert data["results"][0]["success"] is False
@@ -169,7 +169,7 @@ class TestBulkRegistrations:
                 ]
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["failed"] == 1
         assert "not found" in data["results"][0]["error"]
@@ -236,7 +236,7 @@ class TestBulkAssets:
             json={"assets": [{"fqn": "fail.dup.asset", "owner_team_id": team_id}]},
         )
 
-        # Second create should fail
+        # Second create should fail with 207
         resp = await client.post(
             "/api/v1/bulk/assets",
             json={
@@ -244,7 +244,7 @@ class TestBulkAssets:
                 "skip_duplicates": False,
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["failed"] == 1
         assert "already exists" in data["results"][0]["error"]
@@ -262,7 +262,7 @@ class TestBulkAssets:
                 ]
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["failed"] == 1
         # Could fail on authorization or team not found
@@ -518,7 +518,7 @@ class TestBulkAcknowledgments:
                 ]
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["failed"] == 1
         # Should fail because already acknowledged or proposal not pending
@@ -541,7 +541,7 @@ class TestBulkAcknowledgments:
                 ]
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["failed"] == 1
         assert "not found" in data["results"][0]["error"]
@@ -605,13 +605,130 @@ class TestBulkAcknowledgments:
                 "continue_on_error": True,
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["total"] == 2
         assert data["succeeded"] == 1
         assert data["failed"] == 1
         assert data["results"][0]["success"] is False
         assert data["results"][1]["success"] is True
+
+
+class TestBulkMultiStatus:
+    """Tests for HTTP 207 Multi-Status on partial failure (issue #385)."""
+
+    async def test_bulk_assets_partial_failure_returns_207(self, client: AsyncClient) -> None:
+        """Mixed success and failure in bulk assets returns 207."""
+        team_resp = await client.post("/api/v1/teams", json={"name": "multi-status-team"})
+        team_id = team_resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/bulk/assets",
+            json={
+                "assets": [
+                    {"fqn": "ms.good.asset", "owner_team_id": team_id},
+                    {
+                        "fqn": "ms.bad.asset",
+                        "owner_team_id": "00000000-0000-0000-0000-000000000000",
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 207
+        data = resp.json()
+        assert data["total"] == 2
+        assert data["succeeded"] == 1
+        assert data["failed"] == 1
+        assert data["results"][0]["success"] is True
+        assert data["results"][1]["success"] is False
+
+    async def test_bulk_assets_all_success_returns_200(self, client: AsyncClient) -> None:
+        """All-successful bulk assets returns 200."""
+        team_resp = await client.post("/api/v1/teams", json={"name": "all-success-team"})
+        team_id = team_resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/bulk/assets",
+            json={
+                "assets": [
+                    {"fqn": "ok.one.asset", "owner_team_id": team_id},
+                    {"fqn": "ok.two.asset", "owner_team_id": team_id},
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert data["succeeded"] == 2
+        assert data["failed"] == 0
+
+    async def test_bulk_registrations_partial_failure_returns_207(
+        self, client: AsyncClient
+    ) -> None:
+        """Mixed success and failure in bulk registrations returns 207."""
+        team_resp = await client.post("/api/v1/teams", json={"name": "ms-reg-team"})
+        consumer_resp = await client.post("/api/v1/teams", json={"name": "ms-reg-consumer"})
+        team_id = team_resp.json()["id"]
+        consumer_id = consumer_resp.json()["id"]
+
+        asset_resp = await client.post(
+            "/api/v1/assets", json={"fqn": "ms.reg.table", "owner_team_id": team_id}
+        )
+        asset_id = asset_resp.json()["id"]
+
+        contract_resp = await client.post(
+            f"/api/v1/assets/{asset_id}/contracts?published_by={team_id}",
+            json={
+                "version": "1.0.0",
+                "schema": {"type": "object", "properties": {"id": {"type": "integer"}}},
+                "compatibility_mode": "backward",
+            },
+        )
+        contract_id = contract_resp.json()["contract"]["id"]
+
+        resp = await client.post(
+            "/api/v1/bulk/registrations",
+            json={
+                "registrations": [
+                    {"contract_id": contract_id, "consumer_team_id": consumer_id},
+                    {
+                        "contract_id": "00000000-0000-0000-0000-000000000000",
+                        "consumer_team_id": consumer_id,
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 207
+        data = resp.json()
+        assert data["succeeded"] == 1
+        assert data["failed"] == 1
+        assert data["results"][0]["success"] is True
+        assert data["results"][1]["success"] is False
+
+    async def test_bulk_all_failed_returns_207(self, client: AsyncClient) -> None:
+        """All-failed bulk operation returns 207 (not 200)."""
+        consumer_resp = await client.post("/api/v1/teams", json={"name": "all-fail-consumer"})
+        consumer_id = consumer_resp.json()["id"]
+
+        resp = await client.post(
+            "/api/v1/bulk/registrations",
+            json={
+                "registrations": [
+                    {
+                        "contract_id": "00000000-0000-0000-0000-000000000000",
+                        "consumer_team_id": consumer_id,
+                    },
+                    {
+                        "contract_id": "00000000-0000-0000-0000-000000000001",
+                        "consumer_team_id": consumer_id,
+                    },
+                ]
+            },
+        )
+        assert resp.status_code == 207
+        data = resp.json()
+        assert data["succeeded"] == 0
+        assert data["failed"] == 2
 
 
 class TestBulkValidation:

--- a/tests/test_concurrent_operations.py
+++ b/tests/test_concurrent_operations.py
@@ -1128,7 +1128,7 @@ class TestBulkAckEdgeCases:
                 "continue_on_error": True,
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 207
         data = resp.json()
         assert data["succeeded"] == 1
         assert data["failed"] == 1


### PR DESCRIPTION
## Summary

Fixes #385 — bulk sync endpoints were returning HTTP 200 even when some items failed, causing CI pipelines and automation to assume full success.

- All three `/api/v1/bulk/*` endpoints (registrations, assets, acknowledgments) now return **207 Multi-Status** when any items fail
- The dbt upload endpoint (`/api/v1/sync/dbt/upload`) returns 207 with `"status": "partial_success"` when contract publishes or consumer registrations fail
- Fully successful operations still return 200

## Test plan

- [x] Existing tests updated: 7 tests that previously expected 200-on-failure now expect 207
- [x] New `TestBulkMultiStatus` class with 4 tests covering:
  - Mixed success+failure returns 207
  - All-success returns 200
  - Partial failure in registrations returns 207
  - All-failed returns 207
- [x] Full test suite: 1289 passed, 0 failures
- [x] ruff, ruff-format, mypy all pass
- [x] API docs updated for sync and contracts bulk endpoints