### PR TITLE
feat: CODEOWNERS parser service

### DIFF
--- a/src/tessera/services/__init__.py
+++ b/src/tessera/services/__init__.py
@@ -19,6 +19,14 @@ from tessera.services.batch import (
     fetch_asset_counts_by_user,
     fetch_team_names,
 )
+from tessera.services.codeowners import (
+    CodeownersParseResult,
+    CodeownersRule,
+    TeamSuggestion,
+    parse_codeowners,
+    suggest_owners,
+    suggest_owners_bulk,
+)
 from tessera.services.contract_publisher import (
     ContractPublishingWorkflow,
     PublishAction,
@@ -142,4 +150,11 @@ __all__ = [
     # Migration suggester
     "MigrationSuggestion",
     "suggest_migrations",
+    # CODEOWNERS parser
+    "CodeownersParseResult",
+    "CodeownersRule",
+    "TeamSuggestion",
+    "parse_codeowners",
+    "suggest_owners",
+    "suggest_owners_bulk",
 ]

--- a/src/tessera/services/codeowners.py
+++ b/src/tessera/services/codeowners.py
@@ -1,0 +1,400 @@
+"""CODEOWNERS file parser with team ownership suggestion.
+
+Parses GitHub and GitLab CODEOWNERS formats and resolves owners
+against existing Tessera teams using fuzzy name matching.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass, field
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class CodeownersRule:
+    """A single ownership rule parsed from a CODEOWNERS file.
+
+    Attributes:
+        pattern: The glob pattern from the CODEOWNERS file.
+        owners: Raw owner strings (e.g. ``@acme/backend-team``, ``user@example.com``).
+        section: GitLab section name if the rule appeared under a ``[Section]`` header,
+            otherwise ``None``.
+        negation: ``True`` when the pattern starts with ``!`` (excludes matching paths).
+        line_number: 1-based line number in the source file.
+    """
+
+    pattern: str
+    owners: list[str]
+    section: str | None = None
+    negation: bool = False
+    line_number: int = 0
+
+
+@dataclass
+class TeamSuggestion:
+    """A suggested Tessera team mapping for a file path.
+
+    Attributes:
+        path_pattern: The CODEOWNERS glob pattern that matched.
+        raw_owner: The original owner string from the CODEOWNERS file.
+        suggested_team_id: The resolved Tessera team UUID, or ``None`` if no match.
+        suggested_team_name: The resolved Tessera team name, or ``None``.
+        confidence: Match confidence — ``"exact"`` for normalized-equal names,
+            ``"fuzzy"`` for substring/partial matches.
+        section: GitLab section the rule belongs to, if any.
+    """
+
+    path_pattern: str
+    raw_owner: str
+    suggested_team_id: UUID | None = None
+    suggested_team_name: str | None = None
+    confidence: str | None = None
+    section: str | None = None
+
+
+@dataclass
+class CodeownersParseResult:
+    """Full result of parsing a CODEOWNERS file and resolving teams.
+
+    Attributes:
+        rules: All parsed ownership rules.
+        suggestions: Per-owner team suggestions for a specific file (populated
+            by :func:`suggest_owners`).
+        unresolved_owners: Owner strings that could not be matched to any
+            Tessera team.
+    """
+
+    rules: list[CodeownersRule] = field(default_factory=list)
+    suggestions: list[TeamSuggestion] = field(default_factory=list)
+    unresolved_owners: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# GitLab section header pattern: [SectionName] or [SectionName][number]
+# Optional leading ^ for optional approval sections.
+# ---------------------------------------------------------------------------
+_GITLAB_SECTION_RE = re.compile(r"^\^?\[(?P<name>[^\]]+)\](?:\[\d+\])?\s*$")
+
+
+def parse_codeowners(content: str) -> list[CodeownersRule]:
+    """Parse a CODEOWNERS file into a list of ownership rules.
+
+    Supports both GitHub and GitLab formats:
+
+    * **GitHub**: ``<pattern> <owner1> <owner2> ...``
+    * **GitLab**: Same line format, but rules may appear under section headers
+      (``[SectionName]``).
+
+    Lines starting with ``#`` are comments. Blank lines are skipped.
+    Negation patterns (``!pattern``) are preserved with ``negation=True``.
+
+    Args:
+        content: The raw text content of a CODEOWNERS file.
+
+    Returns:
+        A list of :class:`CodeownersRule` in file order.
+    """
+    rules: list[CodeownersRule] = []
+    current_section: str | None = None
+
+    for line_number, raw_line in enumerate(content.splitlines(), start=1):
+        line = raw_line.strip()
+
+        # Skip blanks and comments.
+        if not line or line.startswith("#"):
+            continue
+
+        # Check for a GitLab section header.
+        section_match = _GITLAB_SECTION_RE.match(line)
+        if section_match:
+            current_section = section_match.group("name")
+            continue
+
+        # Split into tokens — pattern is always the first token, rest are owners.
+        tokens = line.split()
+        if len(tokens) < 2:
+            # A line with only a pattern and no owners clears ownership in GitHub
+            # format. We still record it so downstream consumers can see the
+            # explicit "no owner" declaration.
+            pattern = tokens[0]
+            owners: list[str] = []
+        else:
+            pattern = tokens[0]
+            owners = tokens[1:]
+
+        negation = pattern.startswith("!")
+        if negation:
+            pattern = pattern[1:]
+
+        rules.append(
+            CodeownersRule(
+                pattern=pattern,
+                owners=owners,
+                section=current_section,
+                negation=negation,
+                line_number=line_number,
+            )
+        )
+
+    return rules
+
+
+# ---------------------------------------------------------------------------
+# Glob matching
+# ---------------------------------------------------------------------------
+
+
+def _pattern_matches(pattern: str, file_path: str) -> bool:
+    """Test whether a CODEOWNERS glob *pattern* matches *file_path*.
+
+    CODEOWNERS globs follow these conventions:
+
+    * A pattern without a ``/`` matches any file whose **basename** matches
+      (GitHub behaviour: ``*.js`` matches ``src/app.js``).
+    * A pattern starting with ``/`` is anchored to the repo root
+      (``/docs/`` matches ``docs/readme.md``).
+    * A pattern containing ``/`` (other than a leading one) matches relative to
+      the repo root.
+    * A trailing ``/`` means "everything under this directory".
+    * ``**`` matches across directory boundaries.
+    """
+    anchored = pattern.startswith("/")
+    normalized_pattern = pattern.lstrip("/")
+
+    # Trailing slash → match everything under that directory.
+    if normalized_pattern.endswith("/"):
+        normalized_pattern += "**"
+
+    # A pattern with no directory separator AND not anchored matches any path
+    # whose basename matches (like .gitignore's basename-only rule).
+    if "/" not in normalized_pattern and not anchored:
+        basename = file_path.rsplit("/", 1)[-1] if "/" in file_path else file_path
+        return fnmatch.fnmatch(basename, normalized_pattern)
+
+    # fnmatch doesn't natively support `**` across directories, so we convert
+    # to a regex when the pattern contains `**`.
+    if "**" in normalized_pattern:
+        regex = _glob_to_regex(normalized_pattern)
+        return bool(re.match(regex, file_path))
+
+    return fnmatch.fnmatch(file_path, normalized_pattern)
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Convert a CODEOWNERS glob pattern to a regex string.
+
+    Handles ``*``, ``**``, ``?``, and character classes ``[…]``.
+    """
+    i = 0
+    n = len(pattern)
+    result: list[str] = []
+
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < n and pattern[i + 1] == "*":
+                # `**` — match everything including `/`.
+                i += 2
+                if i < n and pattern[i] == "/":
+                    # `**/` — match zero or more directory levels.
+                    i += 1
+                    result.append("(?:.*/)?")
+                else:
+                    # `**` at end of pattern — match anything remaining.
+                    result.append(".*")
+                continue
+            else:
+                # Single `*` — match anything except `/`.
+                result.append("[^/]*")
+        elif c == "?":
+            result.append("[^/]")
+        elif c == "[":
+            # Pass character classes through — find the closing `]`.
+            j = i + 1
+            if j < n and pattern[j] == "!":
+                j += 1
+            if j < n and pattern[j] == "]":
+                j += 1
+            while j < n and pattern[j] != "]":
+                j += 1
+            result.append(pattern[i : j + 1])
+            i = j
+        else:
+            result.append(re.escape(c))
+        i += 1
+
+    return "^" + "".join(result) + "$"
+
+
+# ---------------------------------------------------------------------------
+# Team resolution
+# ---------------------------------------------------------------------------
+
+
+def _normalize_team_name(name: str) -> str:
+    """Normalize a team name for fuzzy comparison.
+
+    Strips org prefixes (``@org/``), converts to lowercase, and replaces
+    hyphens, underscores, and spaces with a single canonical separator.
+    """
+    # Strip leading '@'.
+    if name.startswith("@"):
+        name = name[1:]
+
+    # Strip org prefix (everything before the first `/`).
+    if "/" in name:
+        name = name.rsplit("/", 1)[-1]
+
+    return re.sub(r"[-_\s]+", "-", name.strip().lower())
+
+
+@dataclass(frozen=True)
+class _TeamEntry:
+    """Internal representation of a Tessera team for matching."""
+
+    team_id: UUID
+    raw_name: str
+    normalized: str
+
+
+def resolve_owner(
+    raw_owner: str,
+    teams: list[_TeamEntry],
+) -> tuple[UUID | None, str | None, str | None]:
+    """Resolve a CODEOWNERS owner string to a Tessera team.
+
+    Returns ``(team_id, team_name, confidence)`` or ``(None, None, None)``.
+    """
+    # Email addresses are user references, not team references — skip.
+    if "@" in raw_owner and "/" not in raw_owner and not raw_owner.startswith("@"):
+        return None, None, None
+
+    normalized_owner = _normalize_team_name(raw_owner)
+
+    # Pass 1: exact normalized match.
+    for team in teams:
+        if team.normalized == normalized_owner:
+            return team.team_id, team.raw_name, "exact"
+
+    # Pass 2: substring / containment match (either direction).
+    candidates: list[_TeamEntry] = []
+    for team in teams:
+        if normalized_owner in team.normalized or team.normalized in normalized_owner:
+            candidates.append(team)
+
+    if len(candidates) == 1:
+        t = candidates[0]
+        return t.team_id, t.raw_name, "fuzzy"
+
+    return None, None, None
+
+
+def _build_team_entries(
+    teams: list[tuple[UUID, str]],
+) -> list[_TeamEntry]:
+    """Build normalised team entries from ``(id, name)`` pairs."""
+    return [
+        _TeamEntry(team_id=tid, raw_name=name, normalized=_normalize_team_name(name))
+        for tid, name in teams
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public API: suggest_owners
+# ---------------------------------------------------------------------------
+
+
+def suggest_owners(
+    rules: list[CodeownersRule],
+    file_path: str,
+    teams: list[tuple[UUID, str]] | None = None,
+) -> list[TeamSuggestion]:
+    """Given parsed CODEOWNERS rules and a file path, return ranked team suggestions.
+
+    CODEOWNERS semantics: the **last** matching rule wins.  Negation rules
+    remove a prior match.  This function evaluates all rules in order and
+    returns suggestions for the final effective match.
+
+    Args:
+        rules: Parsed rules from :func:`parse_codeowners`.
+        file_path: Repository-root-relative path to evaluate
+            (e.g. ``"services/orders/api.yaml"``).
+        teams: Optional list of ``(team_id, team_name)`` tuples representing
+            existing Tessera teams.  Used to resolve owner strings to team IDs.
+
+    Returns:
+        A list of :class:`TeamSuggestion`, one per owner in the winning rule.
+        Empty if no rule matches.
+    """
+    team_entries = _build_team_entries(teams or [])
+
+    # CODEOWNERS: last matching non-negated rule wins.
+    # A negation rule cancels a prior match.
+    effective_rule: CodeownersRule | None = None
+
+    for rule in rules:
+        if _pattern_matches(rule.pattern, file_path):
+            if rule.negation:
+                effective_rule = None
+            else:
+                effective_rule = rule
+
+    if effective_rule is None:
+        return []
+
+    suggestions: list[TeamSuggestion] = []
+    for owner in effective_rule.owners:
+        team_id, team_name, confidence = resolve_owner(owner, team_entries)
+        suggestions.append(
+            TeamSuggestion(
+                path_pattern=effective_rule.pattern,
+                raw_owner=owner,
+                suggested_team_id=team_id,
+                suggested_team_name=team_name,
+                confidence=confidence,
+                section=effective_rule.section,
+            )
+        )
+
+    return suggestions
+
+
+def suggest_owners_bulk(
+    rules: list[CodeownersRule],
+    file_paths: list[str],
+    teams: list[tuple[UUID, str]] | None = None,
+) -> CodeownersParseResult:
+    """Evaluate multiple file paths and aggregate team suggestions.
+
+    Convenience wrapper that calls :func:`suggest_owners` for each path and
+    collects unique suggestions and unresolved owners.
+
+    Args:
+        rules: Parsed CODEOWNERS rules.
+        file_paths: Repository-root-relative file paths to evaluate.
+        teams: Tessera teams for resolution.
+
+    Returns:
+        A :class:`CodeownersParseResult` with deduplicated suggestions and
+        unresolved owners.
+    """
+    all_suggestions: list[TeamSuggestion] = []
+    seen_keys: set[tuple[str, str]] = set()
+    unresolved: set[str] = set()
+
+    for path in file_paths:
+        for suggestion in suggest_owners(rules, path, teams):
+            key = (suggestion.path_pattern, suggestion.raw_owner)
+            if key not in seen_keys:
+                seen_keys.add(key)
+                all_suggestions.append(suggestion)
+                if suggestion.suggested_team_id is None:
+                    unresolved.add(suggestion.raw_owner)
+
+    return CodeownersParseResult(
+        rules=rules,
+        suggestions=all_suggestions,
+        unresolved_owners=sorted(unresolved),
+    )

--- a/tests/test_codeowners.py
+++ b/tests/test_codeowners.py
@@ -1,0 +1,487 @@
+"""Tests for the CODEOWNERS parser service."""
+
+from uuid import UUID, uuid4
+
+from tessera.services.codeowners import (
+    _build_team_entries,
+    _normalize_team_name,
+    _pattern_matches,
+    parse_codeowners,
+    resolve_owner,
+    suggest_owners,
+    suggest_owners_bulk,
+)
+
+# ---------------------------------------------------------------------------
+# parse_codeowners — GitHub format
+# ---------------------------------------------------------------------------
+
+
+class TestParseGitHubFormat:
+    """Parsing standard GitHub CODEOWNERS files."""
+
+    def test_basic_rules(self) -> None:
+        content = """\
+# Global owners
+* @acme/platform-team
+
+# Per-directory
+/services/orders/    @acme/commerce-team
+/services/payments/  @acme/commerce-team @acme/fintech-team
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 3
+
+        assert rules[0].pattern == "*"
+        assert rules[0].owners == ["@acme/platform-team"]
+        assert rules[0].section is None
+        assert rules[0].negation is False
+        assert rules[0].line_number == 2
+
+        assert rules[1].pattern == "/services/orders/"
+        assert rules[1].owners == ["@acme/commerce-team"]
+
+        assert rules[2].pattern == "/services/payments/"
+        assert rules[2].owners == ["@acme/commerce-team", "@acme/fintech-team"]
+
+    def test_comments_and_blank_lines_skipped(self) -> None:
+        content = """\
+# This is a comment
+
+# Another comment
+
+*.go @go-team
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 1
+        assert rules[0].pattern == "*.go"
+
+    def test_negation_pattern(self) -> None:
+        content = """\
+/docs/ @docs-team
+!/docs/internal/ @docs-team
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 2
+        assert rules[0].negation is False
+        assert rules[0].pattern == "/docs/"
+        assert rules[1].negation is True
+        assert rules[1].pattern == "/docs/internal/"
+
+    def test_no_owner_line(self) -> None:
+        """A pattern with no owners explicitly unsets ownership."""
+        content = """\
+* @fallback-team
+/vendor/
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 2
+        assert rules[1].pattern == "/vendor/"
+        assert rules[1].owners == []
+
+    def test_email_owners(self) -> None:
+        content = "*.js dev@example.com @frontend-team\n"
+        rules = parse_codeowners(content)
+        assert rules[0].owners == ["dev@example.com", "@frontend-team"]
+
+    def test_empty_content(self) -> None:
+        assert parse_codeowners("") == []
+
+    def test_only_comments(self) -> None:
+        assert parse_codeowners("# just a comment\n# another") == []
+
+    def test_line_numbers_are_correct(self) -> None:
+        content = "# comment\n\n*.py @py-team\n*.js @js-team\n"
+        rules = parse_codeowners(content)
+        assert rules[0].line_number == 3
+        assert rules[1].line_number == 4
+
+
+# ---------------------------------------------------------------------------
+# parse_codeowners — GitLab sections
+# ---------------------------------------------------------------------------
+
+
+class TestParseGitLabSections:
+    """Parsing GitLab CODEOWNERS with [Section] headers."""
+
+    def test_basic_sections(self) -> None:
+        content = """\
+[Backend]
+/services/ @backend-team
+
+[Frontend]
+/web/ @frontend-team
+*.tsx @frontend-team
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 3
+
+        assert rules[0].section == "Backend"
+        assert rules[0].pattern == "/services/"
+        assert rules[0].owners == ["@backend-team"]
+
+        assert rules[1].section == "Frontend"
+        assert rules[1].pattern == "/web/"
+        assert rules[2].section == "Frontend"
+        assert rules[2].pattern == "*.tsx"
+
+    def test_optional_approval_section(self) -> None:
+        """GitLab ``^[Section]`` marks optional approval."""
+        content = """\
+^[Docs]
+/docs/ @docs-team
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 1
+        assert rules[0].section == "Docs"
+
+    def test_section_with_approval_count(self) -> None:
+        """GitLab ``[Section][2]`` requires N approvals."""
+        content = """\
+[Security][2]
+/auth/ @security-team
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 1
+        assert rules[0].section == "Security"
+
+    def test_rules_before_any_section(self) -> None:
+        """Rules before the first section have section=None."""
+        content = """\
+* @fallback
+[Backend]
+/api/ @backend
+"""
+        rules = parse_codeowners(content)
+        assert rules[0].section is None
+        assert rules[1].section == "Backend"
+
+    def test_mixed_github_and_gitlab(self) -> None:
+        """A file can mix global rules with GitLab sections."""
+        content = """\
+# Global fallback
+* @platform
+
+[API]
+/api/ @api-team
+
+# This comment is inside the API section
+/api/v2/ @api-team @v2-lead
+"""
+        rules = parse_codeowners(content)
+        assert len(rules) == 3
+        assert rules[0].section is None
+        assert rules[1].section == "API"
+        assert rules[2].section == "API"
+
+
+# ---------------------------------------------------------------------------
+# Glob matching
+# ---------------------------------------------------------------------------
+
+
+class TestPatternMatching:
+    """CODEOWNERS glob pattern matching."""
+
+    def test_wildcard_matches_all(self) -> None:
+        assert _pattern_matches("*", "anything.py") is True
+        assert _pattern_matches("*", "src/deep/file.py") is True
+
+    def test_extension_glob_basename(self) -> None:
+        """``*.js`` matches any ``.js`` file regardless of directory."""
+        assert _pattern_matches("*.js", "app.js") is True
+        assert _pattern_matches("*.js", "src/components/App.js") is True
+        assert _pattern_matches("*.js", "app.ts") is False
+
+    def test_directory_pattern_trailing_slash(self) -> None:
+        """Trailing slash matches everything under that directory."""
+        assert _pattern_matches("docs/", "docs/readme.md") is True
+        assert _pattern_matches("docs/", "docs/api/endpoints.md") is True
+        assert _pattern_matches("docs/", "src/docs/file.md") is False
+
+    def test_leading_slash_anchored(self) -> None:
+        """/src/ is anchored to repo root."""
+        assert _pattern_matches("/src/", "src/main.py") is True
+        assert _pattern_matches("/src/", "lib/src/main.py") is False
+
+    def test_nested_directory_pattern(self) -> None:
+        assert _pattern_matches("services/orders/", "services/orders/api.yaml") is True
+        assert _pattern_matches("services/orders/", "services/orders/v2/api.yaml") is True
+        assert _pattern_matches("services/orders/", "services/payments/api.yaml") is False
+
+    def test_double_star_any_depth(self) -> None:
+        assert _pattern_matches("docs/**/*.md", "docs/readme.md") is True
+        assert _pattern_matches("docs/**/*.md", "docs/api/endpoints.md") is True
+        assert _pattern_matches("docs/**/*.md", "docs/api/v2/guide.md") is True
+        assert _pattern_matches("docs/**/*.md", "src/readme.md") is False
+
+    def test_question_mark_single_char(self) -> None:
+        assert _pattern_matches("file?.txt", "file1.txt") is True
+        assert _pattern_matches("file?.txt", "fileAB.txt") is False
+
+    def test_character_class(self) -> None:
+        assert _pattern_matches("*.[ch]", "main.c") is True
+        assert _pattern_matches("*.[ch]", "main.h") is True
+        assert _pattern_matches("*.[ch]", "main.o") is False
+
+    def test_specific_file(self) -> None:
+        assert _pattern_matches("Makefile", "Makefile") is True
+        assert _pattern_matches("Makefile", "src/Makefile") is True
+        assert _pattern_matches("/Makefile", "src/Makefile") is False
+
+
+# ---------------------------------------------------------------------------
+# Team name normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTeamName:
+    """Normalizing CODEOWNERS owner strings for fuzzy matching."""
+
+    def test_strip_org_prefix(self) -> None:
+        assert _normalize_team_name("@acme/backend-team") == "backend-team"
+
+    def test_strip_at_sign(self) -> None:
+        assert _normalize_team_name("@backend-team") == "backend-team"
+
+    def test_normalize_underscores(self) -> None:
+        assert _normalize_team_name("backend_team") == "backend-team"
+
+    def test_normalize_spaces(self) -> None:
+        assert _normalize_team_name("Backend Team") == "backend-team"
+
+    def test_mixed_separators(self) -> None:
+        assert _normalize_team_name("@org/My_Cool--Team") == "my-cool-team"
+
+    def test_plain_name(self) -> None:
+        assert _normalize_team_name("platform") == "platform"
+
+
+# ---------------------------------------------------------------------------
+# Owner resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOwner:
+    """Resolving CODEOWNERS owner strings to Tessera teams."""
+
+    def setup_method(self) -> None:
+        self.team_a_id = uuid4()
+        self.team_b_id = uuid4()
+        self.teams = _build_team_entries(
+            [
+                (self.team_a_id, "backend-team"),
+                (self.team_b_id, "Frontend Team"),
+            ]
+        )
+
+    def test_exact_match_with_org_prefix(self) -> None:
+        tid, name, confidence = resolve_owner("@acme/backend-team", self.teams)
+        assert tid == self.team_a_id
+        assert name == "backend-team"
+        assert confidence == "exact"
+
+    def test_exact_match_normalized_spaces(self) -> None:
+        tid, name, confidence = resolve_owner("@org/frontend-team", self.teams)
+        assert tid == self.team_b_id
+        assert name == "Frontend Team"
+        assert confidence == "exact"
+
+    def test_fuzzy_substring_match(self) -> None:
+        """'backend' is a substring of 'backend-team'."""
+        teams = _build_team_entries([(self.team_a_id, "backend-team")])
+        tid, _, confidence = resolve_owner("@org/backend", teams)
+        assert tid == self.team_a_id
+        assert confidence == "fuzzy"
+
+    def test_no_match(self) -> None:
+        tid, name, confidence = resolve_owner("@acme/unknown-team", self.teams)
+        assert tid is None
+        assert name is None
+        assert confidence is None
+
+    def test_email_owner_skipped(self) -> None:
+        """Email addresses are user references, not team references."""
+        tid, name, confidence = resolve_owner("dev@example.com", self.teams)
+        assert tid is None
+
+    def test_ambiguous_substring_returns_none(self) -> None:
+        """Multiple substring matches → no confident resolution."""
+        teams = _build_team_entries(
+            [
+                (uuid4(), "backend-team-a"),
+                (uuid4(), "backend-team-b"),
+            ]
+        )
+        tid, _, _ = resolve_owner("@org/backend-team", teams)
+        assert tid is None
+
+
+# ---------------------------------------------------------------------------
+# suggest_owners
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestOwners:
+    """End-to-end: parse → match → suggest."""
+
+    def setup_method(self) -> None:
+        self.commerce_id = uuid4()
+        self.platform_id = uuid4()
+        self.teams: list[tuple[UUID, str]] = [
+            (self.commerce_id, "commerce-team"),
+            (self.platform_id, "platform-team"),
+        ]
+
+    def test_last_matching_rule_wins(self) -> None:
+        rules = parse_codeowners("""\
+* @acme/platform-team
+/services/orders/ @acme/commerce-team
+""")
+        suggestions = suggest_owners(rules, "services/orders/api.yaml", self.teams)
+        assert len(suggestions) == 1
+        assert suggestions[0].raw_owner == "@acme/commerce-team"
+        assert suggestions[0].suggested_team_id == self.commerce_id
+        assert suggestions[0].confidence == "exact"
+
+    def test_fallback_to_global_rule(self) -> None:
+        rules = parse_codeowners("* @acme/platform-team\n")
+        suggestions = suggest_owners(rules, "random/file.py", self.teams)
+        assert len(suggestions) == 1
+        assert suggestions[0].suggested_team_id == self.platform_id
+
+    def test_negation_cancels_match(self) -> None:
+        rules = parse_codeowners("""\
+/docs/ @acme/platform-team
+!/docs/internal/ @acme/platform-team
+""")
+        suggestions = suggest_owners(rules, "docs/internal/secret.md", self.teams)
+        assert suggestions == []
+
+    def test_no_matching_rule(self) -> None:
+        rules = parse_codeowners("/services/ @acme/commerce-team\n")
+        suggestions = suggest_owners(rules, "unrelated/file.txt", self.teams)
+        assert suggestions == []
+
+    def test_multiple_owners_per_rule(self) -> None:
+        rules = parse_codeowners("/services/ @acme/commerce-team @acme/platform-team\n")
+        suggestions = suggest_owners(rules, "services/orders/api.yaml", self.teams)
+        assert len(suggestions) == 2
+        assert suggestions[0].suggested_team_id == self.commerce_id
+        assert suggestions[1].suggested_team_id == self.platform_id
+
+    def test_unresolved_owner(self) -> None:
+        rules = parse_codeowners("/services/ @acme/mystery-team\n")
+        suggestions = suggest_owners(rules, "services/file.py", self.teams)
+        assert len(suggestions) == 1
+        assert suggestions[0].suggested_team_id is None
+        assert suggestions[0].raw_owner == "@acme/mystery-team"
+
+    def test_no_teams_provided(self) -> None:
+        rules = parse_codeowners("* @acme/any-team\n")
+        suggestions = suggest_owners(rules, "file.py")
+        assert len(suggestions) == 1
+        assert suggestions[0].suggested_team_id is None
+
+    def test_section_propagated(self) -> None:
+        rules = parse_codeowners("""\
+[Backend]
+/api/ @acme/platform-team
+""")
+        suggestions = suggest_owners(rules, "api/routes.py", self.teams)
+        assert len(suggestions) == 1
+        assert suggestions[0].section == "Backend"
+
+    def test_empty_owner_line_clears_ownership(self) -> None:
+        """A pattern-only line (no owners) clears prior ownership."""
+        rules = parse_codeowners("""\
+* @acme/platform-team
+/vendor/
+""")
+        suggestions = suggest_owners(rules, "vendor/lib.py", self.teams)
+        # The /vendor/ rule has no owners, so no suggestions.
+        assert suggestions == []
+
+
+# ---------------------------------------------------------------------------
+# suggest_owners_bulk
+# ---------------------------------------------------------------------------
+
+
+class TestSuggestOwnersBulk:
+    """Bulk evaluation across multiple file paths."""
+
+    def test_deduplicates_suggestions(self) -> None:
+        team_id = uuid4()
+        teams: list[tuple[UUID, str]] = [(team_id, "backend-team")]
+        rules = parse_codeowners("/services/ @acme/backend-team\n")
+        result = suggest_owners_bulk(
+            rules,
+            ["services/a.py", "services/b.py"],
+            teams,
+        )
+        # Same pattern+owner → deduplicated to one suggestion.
+        assert len(result.suggestions) == 1
+        assert result.suggestions[0].suggested_team_id == team_id
+
+    def test_unresolved_owners_collected(self) -> None:
+        rules = parse_codeowners("/api/ @acme/unknown-team\n")
+        result = suggest_owners_bulk(rules, ["api/routes.py"])
+        assert "@acme/unknown-team" in result.unresolved_owners
+
+    def test_empty_paths(self) -> None:
+        rules = parse_codeowners("* @fallback\n")
+        result = suggest_owners_bulk(rules, [])
+        assert result.suggestions == []
+        assert result.unresolved_owners == []
+
+    def test_rules_preserved_in_result(self) -> None:
+        rules = parse_codeowners("* @team\n")
+        result = suggest_owners_bulk(rules, ["f.py"])
+        assert result.rules is rules
+
+
+# ---------------------------------------------------------------------------
+# Malformed / edge-case files
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedFiles:
+    """Graceful handling of unusual CODEOWNERS content."""
+
+    def test_windows_line_endings(self) -> None:
+        content = "*.py @py-team\r\n*.js @js-team\r\n"
+        rules = parse_codeowners(content)
+        assert len(rules) == 2
+        assert rules[0].owners == ["@py-team"]
+
+    def test_tabs_as_separators(self) -> None:
+        content = "*.go\t@go-team\n"
+        rules = parse_codeowners(content)
+        assert rules[0].pattern == "*.go"
+        assert rules[0].owners == ["@go-team"]
+
+    def test_multiple_spaces_between_tokens(self) -> None:
+        content = "*.rs    @rust-team    @systems-team\n"
+        rules = parse_codeowners(content)
+        assert rules[0].owners == ["@rust-team", "@systems-team"]
+
+    def test_inline_comment_not_stripped(self) -> None:
+        """CODEOWNERS does not support inline comments — '#' after tokens is
+        treated as an owner (matches real GitHub behavior)."""
+        content = "*.py @py-team # this is not a comment\n"
+        rules = parse_codeowners(content)
+        # '@py-team', '#', 'this', 'is', 'not', 'a', 'comment' are all owners.
+        assert len(rules[0].owners) == 7
+
+    def test_unicode_section_name(self) -> None:
+        content = "[Équipe Backend]\n/api/ @backend\n"
+        rules = parse_codeowners(content)
+        assert rules[0].section == "Équipe Backend"
+
+    def test_deeply_nested_pattern(self) -> None:
+        content = "/a/b/c/d/e/ @deep-team\n"
+        rules = parse_codeowners(content)
+        suggestions = suggest_owners(rules, "a/b/c/d/e/file.py")
+        assert len(suggestions) == 1


### PR DESCRIPTION
## Summary

Adds a CODEOWNERS file parser service (`services/codeowners.py`) that parses GitHub and GitLab formats and resolves owners to Tessera teams via normalized fuzzy matching.

- `parse_codeowners(content)` — parses CODEOWNERS into a list of `CodeownersRule`
- `suggest_owners(rules, file_path, teams)` — returns ranked `TeamSuggestion` for a file path (last-match-wins semantics, negation support)
- `suggest_owners_bulk(rules, file_paths, teams)` — batch evaluation with deduplication
- Supports GitHub format (glob + owners), GitLab sections (`[Section]`, `^[Optional]`, `[Section][N]`)
- Fuzzy team resolution: strips org prefixes, normalizes hyphens/underscores/spaces, exact then substring matching
- Handles comments, blank lines, negation patterns (`!`), no-owner lines, Windows line endings
- Pure string parsing — no external dependencies
- 53 tests covering parsing, glob matching, team resolution, negation semantics, malformed files, and end-to-end flows

## Test plan

- [x] `DATABASE_URL=sqlite+aiosqlite:///:memory: uv run pytest tests/test_codeowners.py -v` — 53/53 passing
- [x] Full suite passing
- [x] `ruff check`, `ruff format`, `mypy` all clean

Closes #413

## Ancient trivia

The Tunnel of Eupalinos on the island of Samos, commissioned by the tyrant Polycrates around 530 BC, was excavated simultaneously from both ends of a mountain — and the two teams met in the middle with less than a meter of vertical error across 1,036 meters of limestone. The engineering feat required geometric surveying techniques described later by Hero of Alexandria. It remained in use as an aqueduct for over a thousand years. (Source: Apostol, T.M., "The Tunnel of Samos," *Engineering and Science*, 2004, 67(1), pp. 30–40.)