### PR TITLE
fix: add frontend build stage to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 # Tessera Docker Image
 # Using slim-bookworm for duckdb compatibility (pre-built wheels available)
 
+# Stage 1: Build React frontend
+FROM node:20-slim AS frontend-builder
+
+WORKDIR /frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+
+COPY frontend/ ./
+# Vite outputs to ../src/tessera/static/dist relative to frontend/
+RUN npm run build
+
 FROM python:3.11-slim-bookworm AS builder
 
 # Install build dependencies
@@ -17,6 +29,8 @@ WORKDIR /app
 # Copy project files
 COPY pyproject.toml uv.lock README.md ./
 COPY src/ ./src/
+# Overlay the compiled frontend into the static directory
+COPY --from=frontend-builder /src/tessera/static/dist ./src/tessera/static/dist
 COPY examples/ ./examples/
 COPY scripts/ ./scripts/
 COPY tests/fixtures/ ./tests/fixtures/


### PR DESCRIPTION
## Summary

- The `frontend/` React/Vite app was introduced without a corresponding Docker build step
- `static/dist/index.html` never made it into the image, so the SPA catch-all in `main.py` returned 404 on every request to `/`
- Adds a `node:20-slim` `frontend-builder` stage that runs `npm ci && npm run build`, then copies the Vite output into the Python builder before `uv sync`

## Test plan

- [x] `docker compose build` completes cleanly
- [x] `docker compose up -d` brings all three containers to healthy
- [x] `curl http://localhost:8000/` returns HTTP 200 (React SPA)
- [x] `curl http://localhost:8000/health` still returns `{"status":"healthy",...}`
- [x] `curl http://localhost:8000/api/v1/assets` with Bearer token still works

## Footnote

**Option B — Fictional Debate**

*Voltaire vs. Descartes on the missing build step:*

"I think, therefore I compile," said Descartes. "You forgot the frontend." Voltaire sighed: "If God did not exist, it would be necessary to invent Him — and apparently the same is true of your `npm run build` step."