### PR TITLE
fix: dbt type mapper preserves date/time format and infers required fields

### DIFF
--- a/src/tessera/api/sync/dbt/mapper.py
+++ b/src/tessera/api/sync/dbt/mapper.py
@@ -44,6 +44,25 @@ _TYPE_MAPPING: dict[str, str] = {
     "object": "object",
 }
 
+# dbt date/time types → JSON Schema format keyword (RFC 3339 / OpenAPI conventions)
+_FORMAT_MAPPING: dict[str, str] = {
+    "date": "date",
+    "datetime": "date-time",
+    "timestamp": "date-time",
+    "timestamp_ntz": "date-time",
+    "timestamp_tz": "date-time",
+    "time": "time",
+}
+
+
+def not_null_columns_from_guarantees(guarantees: dict[str, Any] | None) -> set[str]:
+    """Extract column names with ``nullability: "never"`` from a guarantees dict."""
+    if not guarantees:
+        return set()
+    nullability = guarantees.get("nullability", {})
+    return {col for col, val in nullability.items() if val == "never"}
+
+
 _RESOURCE_TYPE_MAPPING: dict[str, ResourceType] = {
     "model": ResourceType.MODEL,
     "source": ResourceType.SOURCE,
@@ -57,13 +76,23 @@ def map_dbt_resource_type(dbt_type: str) -> ResourceType:
     return _RESOURCE_TYPE_MAPPING.get(dbt_type, ResourceType.OTHER)
 
 
-def dbt_columns_to_json_schema(columns: dict[str, Any]) -> dict[str, Any]:
+def dbt_columns_to_json_schema(
+    columns: dict[str, Any],
+    not_null_columns: set[str] | None = None,
+) -> dict[str, Any]:
     """Convert dbt column definitions to JSON Schema.
 
     Maps dbt data types to JSON Schema types for compatibility checking.
+    Date/time types include the ``format`` keyword per JSON Schema / RFC 3339.
+
+    Args:
+        columns: dbt columns dict (col_name -> col_info with data_type, description, etc.)
+        not_null_columns: column names known to be non-nullable (e.g. from dbt not_null tests).
+            These are added to the schema's ``required`` array.
     """
     properties: dict[str, Any] = {}
     required: list[str] = []
+    _not_null = not_null_columns or set()
 
     for col_name, col_info in columns.items():
         data_type = (col_info.get("data_type") or "string").lower()
@@ -73,11 +102,19 @@ def dbt_columns_to_json_schema(columns: dict[str, Any]) -> dict[str, Any]:
         json_type = _TYPE_MAPPING.get(base_type, "string")
         prop: dict[str, Any] = {"type": json_type}
 
+        # Add format for date/time types
+        fmt = _FORMAT_MAPPING.get(base_type)
+        if fmt:
+            prop["format"] = fmt
+
         # Add description if present
         if col_info.get("description"):
             prop["description"] = col_info["description"]
 
         properties[col_name] = prop
+
+        if col_name in _not_null:
+            required.append(col_name)
 
     return {
         "type": "object",

--- a/src/tessera/api/sync/dbt/upload_ops.py
+++ b/src/tessera/api/sync/dbt/upload_ops.py
@@ -12,7 +12,10 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tessera.api.sync.dbt.mapper import dbt_columns_to_json_schema
+from tessera.api.sync.dbt.mapper import (
+    dbt_columns_to_json_schema,
+    not_null_columns_from_guarantees,
+)
 from tessera.api.sync.dbt.parser import extract_field_metadata_from_columns
 from tessera.api.sync.helpers import resolve_team_by_name
 from tessera.db import AssetDB, ContractDB, ProposalDB, RegistrationDB, TeamDB
@@ -77,7 +80,8 @@ async def auto_publish_contracts(
 
     for asset, columns, asset_guarantees, compat_mode_str in new_assets:
         try:
-            schema_def = dbt_columns_to_json_schema(columns)
+            nn = not_null_columns_from_guarantees(asset_guarantees)
+            schema_def = dbt_columns_to_json_schema(columns, not_null_columns=nn)
             f_descs, f_tags = extract_field_metadata_from_columns(columns)
             compat_mode = _parse_compat_mode(compat_mode_str, asset.fqn, warnings)
             contracts_to_publish.append(
@@ -96,7 +100,8 @@ async def auto_publish_contracts(
 
     for asset, columns, asset_guarantees, compat_mode_str, _existing in existing_assets:
         try:
-            schema_def = dbt_columns_to_json_schema(columns)
+            nn = not_null_columns_from_guarantees(asset_guarantees)
+            schema_def = dbt_columns_to_json_schema(columns, not_null_columns=nn)
             f_descs, f_tags = extract_field_metadata_from_columns(columns)
             compat_mode = _parse_compat_mode(compat_mode_str, asset.fqn, warnings=None)
             contracts_to_publish.append(
@@ -250,7 +255,8 @@ async def auto_create_proposals(
         team_id,
         user_id,
     ) in assets_for_proposals:
-        proposed_schema = dbt_columns_to_json_schema(columns)
+        nn = not_null_columns_from_guarantees(asset_guarantees)
+        proposed_schema = dbt_columns_to_json_schema(columns, not_null_columns=nn)
         existing_schema = existing_contract.schema_def
 
         diff_result = diff_schemas(existing_schema, proposed_schema)

--- a/tests/test_dbt_mapper.py
+++ b/tests/test_dbt_mapper.py
@@ -1,0 +1,142 @@
+"""Tests for dbt type mapper: format keywords and required field inference."""
+
+import pytest
+
+from tessera.api.sync.dbt.mapper import (
+    dbt_columns_to_json_schema,
+    not_null_columns_from_guarantees,
+)
+
+
+class TestDateTimeFormats:
+    """Date/time types must include the JSON Schema ``format`` keyword."""
+
+    @pytest.mark.parametrize(
+        ("dbt_type", "expected_format"),
+        [
+            ("date", "date"),
+            ("DATE", "date"),
+            ("datetime", "date-time"),
+            ("timestamp", "date-time"),
+            ("TIMESTAMP", "date-time"),
+            ("timestamp_ntz", "date-time"),
+            ("timestamp_tz", "date-time"),
+            ("time", "time"),
+            ("TIME", "time"),
+        ],
+    )
+    def test_format_keyword_present(self, dbt_type: str, expected_format: str) -> None:
+        columns = {"col": {"data_type": dbt_type}}
+        schema = dbt_columns_to_json_schema(columns)
+        prop = schema["properties"]["col"]
+        assert prop["type"] == "string"
+        assert prop["format"] == expected_format
+
+    def test_non_temporal_types_have_no_format(self) -> None:
+        columns = {
+            "name": {"data_type": "varchar"},
+            "age": {"data_type": "integer"},
+            "score": {"data_type": "float"},
+            "active": {"data_type": "boolean"},
+        }
+        schema = dbt_columns_to_json_schema(columns)
+        for col_name in columns:
+            assert "format" not in schema["properties"][col_name]
+
+    def test_timestamp_with_precision_suffix(self) -> None:
+        """``timestamp(6)`` should strip the parenthetical and still get a format."""
+        columns = {"created_at": {"data_type": "timestamp(6)"}}
+        schema = dbt_columns_to_json_schema(columns)
+        prop = schema["properties"]["created_at"]
+        assert prop == {"type": "string", "format": "date-time"}
+
+
+class TestRequiredFromNotNull:
+    """Columns with not_null guarantees should appear in the schema's ``required`` array."""
+
+    def test_not_null_columns_populate_required(self) -> None:
+        columns = {
+            "id": {"data_type": "integer"},
+            "email": {"data_type": "varchar"},
+            "nickname": {"data_type": "varchar"},
+        }
+        schema = dbt_columns_to_json_schema(columns, not_null_columns={"id", "email"})
+        assert sorted(schema["required"]) == ["email", "id"]
+
+    def test_no_not_null_columns_means_empty_required(self) -> None:
+        columns = {"id": {"data_type": "integer"}}
+        schema = dbt_columns_to_json_schema(columns)
+        assert schema["required"] == []
+
+    def test_not_null_columns_none_means_empty_required(self) -> None:
+        columns = {"id": {"data_type": "integer"}}
+        schema = dbt_columns_to_json_schema(columns, not_null_columns=None)
+        assert schema["required"] == []
+
+    def test_not_null_column_not_in_columns_is_ignored(self) -> None:
+        """A not_null column that doesn't exist in the columns dict is silently skipped."""
+        columns = {"id": {"data_type": "integer"}}
+        schema = dbt_columns_to_json_schema(columns, not_null_columns={"id", "ghost_column"})
+        assert schema["required"] == ["id"]
+
+
+class TestNotNullColumnsFromGuarantees:
+    """Extraction of not_null column names from the guarantees dict."""
+
+    def test_extracts_never_nullability(self) -> None:
+        guarantees = {"nullability": {"id": "never", "email": "never"}}
+        assert not_null_columns_from_guarantees(guarantees) == {"id", "email"}
+
+    def test_ignores_non_never_values(self) -> None:
+        guarantees = {"nullability": {"id": "never", "notes": "sometimes"}}
+        result = not_null_columns_from_guarantees(guarantees)
+        assert result == {"id"}
+        assert "notes" not in result
+
+    def test_none_guarantees(self) -> None:
+        assert not_null_columns_from_guarantees(None) == set()
+
+    def test_empty_guarantees(self) -> None:
+        assert not_null_columns_from_guarantees({}) == set()
+
+    def test_guarantees_without_nullability(self) -> None:
+        guarantees = {"custom": [{"type": "unique", "column": "id"}]}
+        assert not_null_columns_from_guarantees(guarantees) == set()
+
+
+class TestSchemaStructure:
+    """General schema structure tests."""
+
+    def test_empty_columns(self) -> None:
+        schema = dbt_columns_to_json_schema({})
+        assert schema == {"type": "object", "properties": {}, "required": []}
+
+    def test_description_preserved(self) -> None:
+        columns = {"id": {"data_type": "integer", "description": "Primary key"}}
+        schema = dbt_columns_to_json_schema(columns)
+        assert schema["properties"]["id"]["description"] == "Primary key"
+
+    def test_missing_data_type_defaults_to_string(self) -> None:
+        columns = {"mystery": {}}
+        schema = dbt_columns_to_json_schema(columns)
+        assert schema["properties"]["mystery"]["type"] == "string"
+
+    def test_unknown_type_defaults_to_string(self) -> None:
+        columns = {"geo": {"data_type": "geography"}}
+        schema = dbt_columns_to_json_schema(columns)
+        assert schema["properties"]["geo"]["type"] == "string"
+
+    def test_combined_format_and_required(self) -> None:
+        """A timestamp column with not_null should have both format and required."""
+        columns = {
+            "created_at": {"data_type": "timestamp"},
+            "updated_at": {"data_type": "timestamp"},
+            "deleted_at": {"data_type": "timestamp"},
+        }
+        schema = dbt_columns_to_json_schema(columns, not_null_columns={"created_at", "updated_at"})
+        assert schema["properties"]["created_at"] == {
+            "type": "string",
+            "format": "date-time",
+        }
+        assert sorted(schema["required"]) == ["created_at", "updated_at"]
+        assert "deleted_at" not in schema["required"]


### PR DESCRIPTION
## Summary

Fixes two information-loss bugs in the dbt-to-JSON-Schema mapper (`api/sync/dbt/mapper.py`):

- **Date/time format keyword**: All temporal types (DATE, TIMESTAMP, TIME, etc.) now emit the JSON Schema `format` keyword (`"date"`, `"date-time"`, `"time"`) instead of bare `{"type": "string"}`. Consumers can now distinguish date columns from text columns in contract schemas.
- **Required field inference**: Columns with `not_null` dbt tests now appear in the schema's `required` array. Previously the array was always empty. The `upload_ops.py` call sites now extract nullability from the guarantees dict and pass it through.

Closes #388

## Test plan

- [x] 25 new unit tests in `tests/test_dbt_mapper.py` covering:
  - All 9 date/time type → format mappings (including case-insensitive and precision suffixes like `timestamp(6)`)
  - Non-temporal types have no format key
  - `not_null_columns` populates `required` array; absent/None means empty
  - `not_null_columns_from_guarantees` helper: extracts `"never"` entries, ignores others, handles None/empty
  - Combined format + required on the same column
  - Edge cases: empty columns, missing data_type, unknown types, ghost not_null columns
- [x] All 26 existing `test_sync.py` tests still pass
- [x] ruff, ruff-format, mypy all clean

## Footnote

In 1932, the Danish physicist Niels Bohr was given a house by the Carlsberg brewery — located next to the brewery itself — with a direct pipeline of free beer connected to it. The house, known as the Æresbolig (House of Honour), was intended for Denmark's most distinguished citizen, and Bohr lived there until his death in 1962.