### PR TITLE
feat: audit-log skipped contracts in bulk publish

### DIFF
--- a/src/tessera/services/audit.py
+++ b/src/tessera/services/audit.py
@@ -49,6 +49,7 @@ class AuditAction(StrEnum):
     CONTRACT_DEPRECATED = "contract.deprecated"
     CONTRACT_FORCE_PUBLISHED = "contract.force_published"
     CONTRACT_GUARANTEES_UPDATED = "contract.guarantees_updated"
+    CONTRACT_PUBLISH_SKIPPED = "contract.publish_skipped"
 
     # Registration actions
     REGISTRATION_CREATED = "registration.created"
@@ -223,6 +224,40 @@ async def log_contract_deprecated(
             "version": version,
             "superseded_by": str(superseded_by),
             "superseded_by_version": superseded_by_version,
+        },
+    )
+
+
+async def log_contract_publish_skipped(
+    session: AsyncSession,
+    asset_id: UUID,
+    publisher_id: UUID,
+    asset_fqn: str,
+    current_version: str,
+    reason: str,
+) -> AuditEventDB:
+    """Log that a contract publish was attempted but skipped.
+
+    Records that a bulk-publish evaluated an asset and determined no action
+    was needed. Closes the audit gap where skipped contracts left no trace.
+
+    Args:
+        asset_id: ID of the asset whose contract was evaluated.
+        publisher_id: Team ID that initiated the publish.
+        asset_fqn: Fully qualified name of the asset.
+        current_version: The version that remains active (unchanged).
+        reason: Why the publish was skipped (e.g. "No schema changes detected").
+    """
+    return await log_event(
+        session=session,
+        entity_type="contract",
+        entity_id=asset_id,
+        action=AuditAction.CONTRACT_PUBLISH_SKIPPED,
+        actor_id=publisher_id,
+        payload={
+            "asset_fqn": asset_fqn,
+            "current_version": current_version,
+            "reason": reason,
         },
     )
 

--- a/src/tessera/services/contract_publisher.py
+++ b/src/tessera/services/contract_publisher.py
@@ -31,6 +31,7 @@ from tessera.services.affected_parties import get_affected_parties
 from tessera.services.audit import (
     compute_schema_hash,
     log_contract_deprecated,
+    log_contract_publish_skipped,
     log_contract_published,
     log_guarantees_updated,
     log_proposal_created,
@@ -299,13 +300,26 @@ async def bulk_publish_contracts(
 
                 # No changes - skip
                 if not diff_result.has_changes:
+                    skip_reason = "No schema changes detected"
+                    if not dry_run:
+                        # current_version is always set here — we're past
+                        # the `if not current_contract` early-return above.
+                        assert current_version is not None
+                        await log_contract_publish_skipped(
+                            session=session,
+                            asset_id=item.asset_id,
+                            publisher_id=published_by,
+                            asset_fqn=asset.fqn,
+                            current_version=current_version,
+                            reason=skip_reason,
+                        )
                     results.append(
                         PublishResult(
                             asset_id=item.asset_id,
                             asset_fqn=asset.fqn,
                             status="will_skip" if dry_run else "skipped",
                             current_version=current_version,
-                            reason="No schema changes detected",
+                            reason=skip_reason,
                         )
                     )
                     skipped_count += 1

--- a/tests/test_audit_completeness.py
+++ b/tests/test_audit_completeness.py
@@ -328,6 +328,101 @@ class TestProposalAuditEvents:
         assert events[0].payload["reason"] == "We need migration time"
 
 
+class TestContractPublishSkippedAudit:
+    """Verify bulk publish with unchanged schema creates a skip audit event."""
+
+    async def test_bulk_publish_unchanged_schema_creates_skip_audit(
+        self, client: AsyncClient, test_session: AsyncSession
+    ):
+        # Create team and asset
+        team_resp = await client.post("/api/v1/teams", json={"name": "audit-skip-team"})
+        team_id = team_resp.json()["id"]
+
+        asset_resp = await client.post(
+            "/api/v1/assets",
+            json={"fqn": "db.schema.audit_skip_test", "owner_team_id": team_id},
+        )
+        asset_id = asset_resp.json()["id"]
+
+        schema = {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}, "name": {"type": "string"}},
+            "required": ["id"],
+        }
+
+        # Publish initial contract
+        await client.post(
+            f"/api/v1/assets/{asset_id}/publish?published_by={team_id}",
+            json={"version": "1.0.0", "schema": schema},
+        )
+
+        # Bulk-publish with the same schema (non-dry-run) → should be skipped
+        resp = await client.post(
+            "/api/v1/contracts/bulk?dry_run=false",
+            json={
+                "published_by": team_id,
+                "contracts": [{"asset_id": asset_id, "schema": schema}],
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["skipped"] == 1
+        assert body["results"][0]["status"] == "skipped"
+
+        # Verify audit event was created
+        events = await _get_audit_events(test_session, "contract.publish_skipped")
+        matching = [e for e in events if str(e.entity_id) == asset_id]
+        assert len(matching) == 1
+
+        event = matching[0]
+        assert event.entity_type == "contract"
+        assert event.actor_id == UUID(team_id)
+        assert event.payload["asset_fqn"] == "db.schema.audit_skip_test"
+        assert event.payload["current_version"] == "1.0.0"
+        assert event.payload["reason"] == "No schema changes detected"
+
+    async def test_bulk_publish_dry_run_does_not_create_skip_audit(
+        self, client: AsyncClient, test_session: AsyncSession
+    ):
+        # Create team and asset
+        team_resp = await client.post("/api/v1/teams", json={"name": "audit-skip-dry-team"})
+        team_id = team_resp.json()["id"]
+
+        asset_resp = await client.post(
+            "/api/v1/assets",
+            json={"fqn": "db.schema.audit_skip_dry_test", "owner_team_id": team_id},
+        )
+        asset_id = asset_resp.json()["id"]
+
+        schema = {
+            "type": "object",
+            "properties": {"id": {"type": "integer"}},
+            "required": ["id"],
+        }
+
+        # Publish initial contract
+        await client.post(
+            f"/api/v1/assets/{asset_id}/publish?published_by={team_id}",
+            json={"version": "1.0.0", "schema": schema},
+        )
+
+        # Bulk-publish with same schema in dry_run mode (default)
+        resp = await client.post(
+            "/api/v1/contracts/bulk",
+            json={
+                "published_by": team_id,
+                "contracts": [{"asset_id": asset_id, "schema": schema}],
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["results"][0]["status"] == "will_skip"
+
+        # Verify NO audit event was created for this asset
+        events = await _get_audit_events(test_session, "contract.publish_skipped")
+        matching = [e for e in events if str(e.entity_id) == asset_id]
+        assert len(matching) == 0
+
+
 class TestBulkAuditEvents:
     """Verify bulk operations create audit events."""
 


### PR DESCRIPTION
Closes #386

## Summary

- Adds `CONTRACT_PUBLISH_SKIPPED` (`contract.publish_skipped`) to the `AuditAction` enum
- Adds `log_contract_publish_skipped()` helper that records asset FQN, current version, and skip reason
- Calls the new audit logger in `bulk_publish_contracts()` when a contract is skipped due to no schema changes (non-dry-run only)
- Two new tests: one verifying the audit event is created on skip, one verifying dry-run does **not** create an audit event

## Test plan

- [x] `TestContractPublishSkippedAudit::test_bulk_publish_unchanged_schema_creates_skip_audit` — bulk publish with identical schema creates `contract.publish_skipped` audit event with correct payload
- [x] `TestContractPublishSkippedAudit::test_bulk_publish_dry_run_does_not_create_skip_audit` — dry-run mode does not persist any audit event
- [x] Full test suite passes (1838 passed, 1 skipped)
- [x] mypy, ruff check, ruff format all clean

## Footnote

In 1903, mathematician Frank Nelson Cole delivered a lecture to the American Mathematical Society titled "On the Factorisation of Large Numbers." He walked to the chalkboard, silently computed 2^67 − 1 = 147,573,952,589,676,412,927, then multiplied 193,707,721 × 761,838,257,287 to produce the same number — proving that the 67th Mersenne number was composite. He sat down without speaking a word. The audience applauded.